### PR TITLE
M1: Define API interfaces for datasource and visualizer plugins

### DIFF
--- a/api/graph_api/__init__.py
+++ b/api/graph_api/__init__.py
@@ -1,1 +1,5 @@
-"""TODO: Initialize graph_api package."""
+"""Public API exports for graph_api plugin contracts."""
+
+from .services import DataSourcePlugin, VisualizerPlugin
+
+__all__ = ["DataSourcePlugin", "VisualizerPlugin"]

--- a/api/graph_api/services/__init__.py
+++ b/api/graph_api/services/__init__.py
@@ -1,1 +1,6 @@
-"""TODO: Add API service placeholders."""
+"""Service-level plugin contracts for graph_api."""
+
+from .datasource_plugin import DataSourcePlugin
+from .visualizer_plugin import VisualizerPlugin
+
+__all__ = ["DataSourcePlugin", "VisualizerPlugin"]

--- a/api/graph_api/services/datasource_plugin.py
+++ b/api/graph_api/services/datasource_plugin.py
@@ -1,0 +1,32 @@
+"""Datasource plugin interface definitions."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+# TODO: Replace with a concrete graph model class when model contracts are defined.
+Graph = Any
+
+
+class DataSourcePlugin(ABC):
+    """Contract for plugins that load graph data from external sources."""
+
+    @property
+    @abstractmethod
+    def plugin_id(self) -> str:
+        """Return a unique, stable plugin identifier."""
+
+    @property
+    @abstractmethod
+    def display_name(self) -> str:
+        """Return a human-readable plugin name for UI and logs."""
+
+    def parameters_schema(self) -> dict[str, Any] | None:
+        """Return an optional parameter schema for UI/platform integration."""
+        # TODO: Replace generic dict schema with a shared typed schema contract.
+        return None
+
+    @abstractmethod
+    def load_graph(self, source: Any, **options: Any) -> "Graph":
+        """Load and return a graph object from the provided source."""

--- a/api/graph_api/services/visualizer_plugin.py
+++ b/api/graph_api/services/visualizer_plugin.py
@@ -1,0 +1,32 @@
+"""Visualizer plugin interface definitions."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+# TODO: Replace with a concrete graph model class when model contracts are defined.
+Graph = Any
+
+
+class VisualizerPlugin(ABC):
+    """Contract for plugins that render graph objects to HTML output."""
+
+    @property
+    @abstractmethod
+    def plugin_id(self) -> str:
+        """Return a unique, stable plugin identifier."""
+
+    @property
+    @abstractmethod
+    def display_name(self) -> str:
+        """Return a human-readable plugin name for UI and logs."""
+
+    def render_options_schema(self) -> dict[str, Any] | None:
+        """Return an optional render options schema for UI/platform integration."""
+        # TODO: Replace generic dict schema with a shared typed schema contract.
+        return None
+
+    @abstractmethod
+    def render(self, graph: "Graph", **options: Any) -> str:
+        """Render the provided graph and return HTML output."""


### PR DESCRIPTION
Closes #3

Added abstract plugin API contracts in the `api` component:
- DataSourcePlugin interface
- VisualizerPlugin interface

This establishes the shared contract for platform and plugin development.
No concrete plugin implementations included.