### PR TITLE
M2: Implement frontend mock integration and view state wiring in graph_explorer

### DIFF
--- a/graph_explorer/explorer/templates/explorer/index.html
+++ b/graph_explorer/explorer/templates/explorer/index.html
@@ -42,27 +42,38 @@
         <section id="visualizer-controls" class="panel">
             <h2 class="panel-title">Visualizer</h2>
             <div class="tab-buttons" role="tablist" aria-label="Visualizer selector">
-                <button type="button" class="tab-button active" aria-selected="true">Simple view</button>
-                <button type="button" class="tab-button" aria-selected="false">Block view</button>
+                <button type="button" class="tab-button active" data-visualizer="simple" aria-selected="true">Simple view</button>
+                <button type="button" class="tab-button" data-visualizer="block" aria-selected="false">Block view</button>
             </div>
-            <p class="panel-note">TODO: connect visualizer plugins.</p>
+            <p id="visualizer-panel-note" class="panel-note">Active visualizer: simple</p>
         </section>
 
         <section id="tree-view-panel" class="panel">
             <h2 class="panel-title">Tree View</h2>
-            <div class="panel-body placeholder-box">Tree view placeholder</div>
+            <div id="tree-view-content" class="panel-body placeholder-box render-surface">
+                Tree view placeholder
+            </div>
         </section>
 
         <section id="bird-view-panel" class="panel">
             <h2 class="panel-title">Bird View</h2>
-            <div class="panel-body placeholder-box">Bird view placeholder</div>
+            <div id="bird-view-content" class="panel-body placeholder-box render-surface">
+                Bird view placeholder
+            </div>
+        </section>
+
+        <section id="console-panel" class="panel">
+            <h2 class="panel-title">Console</h2>
+            <div class="panel-body placeholder-box render-surface">
+                TODO: future command input and execution controls.
+            </div>
         </section>
     </aside>
 
     <main id="main-content" class="main-content">
         <section id="main-view-panel" class="panel main-panel">
             <h2 class="panel-title">Main View</h2>
-            <div id="main-view-content" class="panel-body placeholder-box">
+            <div id="main-view-content" class="panel-body placeholder-box render-surface">
                 {{ placeholder_message }}
                 <p>TODO: plugin render output will be injected here</p>
             </div>

--- a/graph_explorer/static/css/graph_explorer.css
+++ b/graph_explorer/static/css/graph_explorer.css
@@ -90,7 +90,7 @@ body {
 
 .sidebar {
     display: grid;
-    grid-template-rows: auto 1fr 1fr;
+    grid-template-rows: auto 1fr 1fr auto;
     gap: 0.75rem;
 }
 
@@ -165,6 +165,113 @@ body {
     min-height: 420px;
 }
 
+.render-surface {
+    display: block;
+    text-align: left;
+    align-items: stretch;
+    justify-content: flex-start;
+    overflow: auto;
+}
+
+.view-meta {
+    margin: 0 0 0.4rem;
+    font-size: 0.86rem;
+    color: var(--muted);
+}
+
+.node-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+    gap: 0.55rem;
+    margin: 0.55rem 0 0.8rem;
+}
+
+.node-card {
+    border: 1px solid #c9d6e3;
+    background: #ffffff;
+    border-radius: 6px;
+    padding: 0.55rem;
+    text-align: left;
+    cursor: pointer;
+    color: var(--text);
+}
+
+.node-card:hover {
+    border-color: #86a8cd;
+    background: #f8fbff;
+}
+
+.node-card.selected {
+    border-color: var(--accent);
+    background: #eaf2fd;
+}
+
+.node-card-title {
+    margin: 0 0 0.35rem;
+    font-size: 0.88rem;
+    font-weight: 700;
+}
+
+.node-card-meta {
+    margin: 0.2rem 0;
+    font-size: 0.8rem;
+    color: #46586d;
+}
+
+.placeholder-list {
+    margin: 0;
+    padding-left: 1.1rem;
+}
+
+.placeholder-list li {
+    margin: 0.2rem 0;
+    font-size: 0.84rem;
+    color: #3e5168;
+}
+
+.tree-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.tree-item {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.28rem 0.35rem;
+    border-radius: 4px;
+    font-size: 0.84rem;
+}
+
+.tree-item.selected {
+    background: #eaf2fd;
+    color: #0e3d74;
+    font-weight: 700;
+}
+
+.tree-marker {
+    width: 0.8rem;
+    color: var(--accent);
+}
+
+.visualizer-pill {
+    display: inline-block;
+    border: 1px solid #bfd2ea;
+    background: #eaf3ff;
+    color: #19467d;
+    border-radius: 999px;
+    padding: 0.05rem 0.45rem;
+    font-size: 0.78rem;
+    text-transform: lowercase;
+}
+
+.empty-note {
+    margin: 0.3rem 0;
+    font-size: 0.84rem;
+    color: var(--muted);
+}
+
 @media (max-width: 980px) {
     .app-shell {
         grid-template-columns: 1fr;
@@ -177,6 +284,6 @@ body {
 
     .sidebar {
         grid-template-columns: 1fr;
-        grid-template-rows: auto auto auto;
+        grid-template-rows: auto auto auto auto;
     }
 }

--- a/graph_explorer/static/js/app.js
+++ b/graph_explorer/static/js/app.js
@@ -1,32 +1,264 @@
 (function () {
     "use strict";
 
-    // TODO: add D3-based rendering pipeline for the active graph visualizer.
-    // TODO: implement synchronized focus/selection between Main, Tree, and Bird views.
-    // TODO: replace local mock usage with platform/API-provided graph payloads.
-    function renderPlaceholderStats() {
-        const mainView = document.getElementById("main-view-content");
-        const graph = window.GRAPH_EXPLORER_MOCK_GRAPH;
+    // TODO: add D3-based rendering for the active visualizer in Main View.
+    // TODO: improve focus synchronization behavior across Main/Tree/Bird interactions.
+    // TODO: replace mock data state with platform/API integration payloads.
+    const state = {
+        activeVisualizer: "simple",
+        selectedNodeId: null,
+        graph: window.GRAPH_EXPLORER_MOCK_GRAPH || { nodes: [], edges: [] }
+    };
 
-        if (!mainView || !graph) {
+    function escapeHtml(value) {
+        return String(value)
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#039;");
+    }
+
+    function getNodes() {
+        if (!state.graph || !Array.isArray(state.graph.nodes)) {
+            return [];
+        }
+        return state.graph.nodes;
+    }
+
+    function getEdges() {
+        if (!state.graph || !Array.isArray(state.graph.edges)) {
+            return [];
+        }
+        return state.graph.edges;
+    }
+
+    function getNodeById(nodeId) {
+        const nodes = getNodes();
+        for (let i = 0; i < nodes.length; i += 1) {
+            if (nodes[i] && String(nodes[i].id) === String(nodeId)) {
+                return nodes[i];
+            }
+        }
+        return null;
+    }
+
+    function getNodeAttributes(node, maxCount) {
+        const max = typeof maxCount === "number" ? maxCount : 3;
+        const attrs = [];
+        const preferredKeys = ["label", "name", "type", "status", "group"];
+        const used = {};
+
+        for (let i = 0; i < preferredKeys.length && attrs.length < max; i += 1) {
+            const key = preferredKeys[i];
+            if (node[key] !== undefined && node[key] !== null && key !== "id") {
+                attrs.push({ key: key, value: node[key] });
+                used[key] = true;
+            }
+        }
+
+        const keys = Object.keys(node);
+        for (let i = 0; i < keys.length && attrs.length < max; i += 1) {
+            const key = keys[i];
+            if (key === "id" || used[key]) {
+                continue;
+            }
+            if (node[key] !== undefined && node[key] !== null) {
+                attrs.push({ key: key, value: node[key] });
+            }
+        }
+
+        return attrs;
+    }
+
+    function syncSelectedNode() {
+        if (state.selectedNodeId && !getNodeById(state.selectedNodeId)) {
+            state.selectedNodeId = null;
+        }
+    }
+
+    function setSelectedNode(nodeId) {
+        state.selectedNodeId = nodeId ? String(nodeId) : null;
+        renderAll();
+    }
+
+    function setActiveVisualizer(mode) {
+        if (mode !== "simple" && mode !== "block") {
+            return;
+        }
+        if (state.activeVisualizer === mode) {
+            return;
+        }
+        state.activeVisualizer = mode;
+        renderAll();
+    }
+
+    function bindMainNodeCardClicks(mainView) {
+        const cards = mainView.querySelectorAll("[data-node-id]");
+        cards.forEach(function (card) {
+            card.addEventListener("click", function () {
+                const encodedId = card.getAttribute("data-node-id");
+                if (!encodedId) {
+                    setSelectedNode(null);
+                } else {
+                    try {
+                        setSelectedNode(decodeURIComponent(encodedId));
+                    } catch (error) {
+                        setSelectedNode(encodedId);
+                    }
+                }
+            });
+        });
+    }
+
+    function renderMainView() {
+        const mainView = document.getElementById("main-view-content");
+        if (!mainView) {
             return;
         }
 
-        const nodeCount = Array.isArray(graph.nodes) ? graph.nodes.length : 0;
-        const edgeCount = Array.isArray(graph.edges) ? graph.edges.length : 0;
+        const nodes = getNodes();
+        const edges = getEdges();
 
-        // TODO: replace placeholder text with real graph rendering integration (D3/plugin output).
+        const nodeCards = nodes.length
+            ? nodes.map(function (node) {
+                const rawNodeId = node.id !== undefined && node.id !== null ? String(node.id) : "unknown";
+                const nodeIdLabel = escapeHtml(rawNodeId);
+                const nodeIdAttr = encodeURIComponent(rawNodeId);
+                const attrs = getNodeAttributes(node, 3)
+                    .map(function (attr) {
+                        return `<p class="node-card-meta">${escapeHtml(attr.key)}: ${escapeHtml(attr.value)}</p>`;
+                    })
+                    .join("");
+                const selectedClass = rawNodeId === state.selectedNodeId ? " selected" : "";
+                return [
+                    `<button type="button" class="node-card${selectedClass}" data-node-id="${nodeIdAttr}">`,
+                    `<p class="node-card-title">Node: ${nodeIdLabel}</p>`,
+                    attrs || '<p class="node-card-meta">No extra attributes</p>',
+                    "</button>"
+                ].join("");
+            }).join("")
+            : '<p class="empty-note">No nodes available in mock graph.</p>';
+
+        const edgeRows = edges.length
+            ? edges.map(function (edge) {
+                const edgeId = edge.id ? `${escapeHtml(edge.id)}: ` : "";
+                const source = escapeHtml(edge.source || "?");
+                const target = escapeHtml(edge.target || "?");
+                return `<li>${edgeId}${source} -> ${target}</li>`;
+            }).join("")
+            : "<li>No edges available in mock graph.</li>";
+
         mainView.innerHTML = [
-            "<div>",
-            "<p><strong>Main graph placeholder</strong></p>",
-            "<p>TODO: plugin render output will be injected here</p>",
-            `<p>Nodes: ${nodeCount}</p>`,
-            `<p>Edges: ${edgeCount}</p>`,
-            "</div>"
+            '<p class="view-meta"><strong>Main View placeholder</strong></p>',
+            `<p class="view-meta">Active visualizer: <span class="visualizer-pill">${escapeHtml(state.activeVisualizer)}</span></p>`,
+            `<p class="view-meta">Nodes: ${nodes.length} | Edges: ${edges.length}</p>`,
+            `<div class="node-cards">${nodeCards}</div>`,
+            '<p class="view-meta"><strong>Edges</strong></p>',
+            `<ul class="placeholder-list">${edgeRows}</ul>`
+        ].join("");
+
+        bindMainNodeCardClicks(mainView);
+    }
+
+    function renderTreeView() {
+        const treeView = document.getElementById("tree-view-content");
+        if (!treeView) {
+            return;
+        }
+
+        const nodes = getNodes();
+        if (!nodes.length) {
+            treeView.innerHTML = '<p class="empty-note">Tree placeholder: no nodes to list.</p>';
+            return;
+        }
+
+        const treeItems = nodes.map(function (node) {
+            const rawNodeId = node.id !== undefined && node.id !== null ? String(node.id) : "unknown";
+            const isSelected = rawNodeId === state.selectedNodeId;
+            const selectedClass = isSelected ? " selected" : "";
+            const marker = isSelected ? "●" : "○";
+            const label = node.label ? ` - ${escapeHtml(node.label)}` : "";
+            return [
+                `<li class="tree-item${selectedClass}">`,
+                `<span class="tree-marker">${marker}</span>`,
+                `<span>${escapeHtml(rawNodeId)}${label}</span>`,
+                "</li>"
+            ].join("");
+        }).join("");
+
+        treeView.innerHTML = [
+            '<p class="view-meta"><strong>Tree placeholder</strong></p>',
+            `<ul class="tree-list">${treeItems}</ul>`
         ].join("");
     }
 
+    function renderBirdView() {
+        const birdView = document.getElementById("bird-view-content");
+        if (!birdView) {
+            return;
+        }
+
+        const nodes = getNodes();
+        const edges = getEdges();
+        const selectedNode = state.selectedNodeId ? getNodeById(state.selectedNodeId) : null;
+
+        let selectedSummary = '<p class="empty-note">Selected node: none</p>';
+        if (selectedNode) {
+            const selectedAttrs = getNodeAttributes(selectedNode, 2)
+                .map(function (attr) {
+                    return `${escapeHtml(attr.key)}=${escapeHtml(attr.value)}`;
+                })
+                .join(", ");
+            selectedSummary = [
+                `<p class="view-meta">Selected node: <strong>${escapeHtml(selectedNode.id)}</strong></p>`,
+                `<p class="view-meta">${selectedAttrs || "No additional attributes"}</p>`
+            ].join("");
+        }
+
+        birdView.innerHTML = [
+            '<p class="view-meta"><strong>Bird placeholder overview</strong></p>',
+            `<p class="view-meta">Active visualizer: <span class="visualizer-pill">${escapeHtml(state.activeVisualizer)}</span></p>`,
+            `<p class="view-meta">Nodes: ${nodes.length} | Edges: ${edges.length}</p>`,
+            selectedSummary
+        ].join("");
+    }
+
+    function renderUIState() {
+        const buttons = document.querySelectorAll("#visualizer-controls .tab-button[data-visualizer]");
+        buttons.forEach(function (button) {
+            const visualizerId = button.getAttribute("data-visualizer");
+            const isActive = visualizerId === state.activeVisualizer;
+            button.classList.toggle("active", isActive);
+            button.setAttribute("aria-selected", String(isActive));
+        });
+
+        const panelNote = document.getElementById("visualizer-panel-note");
+        if (panelNote) {
+            panelNote.textContent = `Active visualizer: ${state.activeVisualizer}`;
+        }
+    }
+
+    function bindVisualizerTabClicks() {
+        const buttons = document.querySelectorAll("#visualizer-controls .tab-button[data-visualizer]");
+        buttons.forEach(function (button) {
+            button.addEventListener("click", function () {
+                const visualizerId = button.getAttribute("data-visualizer");
+                setActiveVisualizer(visualizerId);
+            });
+        });
+    }
+
+    function renderAll() {
+        syncSelectedNode();
+        renderUIState();
+        renderMainView();
+        renderTreeView();
+        renderBirdView();
+    }
+
     document.addEventListener("DOMContentLoaded", function () {
-        renderPlaceholderStats();
+        bindVisualizerTabClicks();
+        renderAll();
     });
 })();


### PR DESCRIPTION
Closes #7

Implemented frontend-only mock integration and basic UI state wiring in `graph_explorer`.

Included:
- mock graph placeholder rendering in Main View (nodes + edges)
- Tree View and Bird View placeholder rendering from the same mock graph state
- frontend state for active visualizer and selected node
- basic UI wiring (visualizer tab switch, node selection)
- synchronized placeholder updates across Main/Tree/Bird views
- Console/CLI panel placeholder (UI only, no command logic)

Not included:
- real plugin/platform integration
- backend search/filter logic
- final D3 rendering