### PR TITLE
M2: Implement query/filter UI state and applied query chips in graph_explorer

### DIFF
--- a/graph_explorer/explorer/templates/explorer/index.html
+++ b/graph_explorer/explorer/templates/explorer/index.html
@@ -11,13 +11,24 @@
 
         <section id="search-area" class="toolbar-group">
             <h2 class="group-title">Search</h2>
-            <input type="text" placeholder="Search nodes or edges" aria-label="Search placeholder">
+            <input
+                id="search-input"
+                type="text"
+                placeholder="Search nodes or edges"
+                aria-label="Search text"
+            >
+            <p id="search-preview" class="toolbar-feedback">Current search: none</p>
         </section>
 
         <section id="filter-area" class="toolbar-group">
             <h2 class="group-title">Filters</h2>
-            <input type="text" placeholder="Filter key" aria-label="Filter key placeholder">
-            <select aria-label="Filter operator placeholder">
+            <input
+                id="filter-attribute-input"
+                type="text"
+                placeholder="Filter key"
+                aria-label="Filter attribute"
+            >
+            <select id="filter-operator-select" aria-label="Filter operator">
                 <option>==</option>
                 <option>!=</option>
                 <option>&gt;</option>
@@ -25,16 +36,23 @@
                 <option>&lt;</option>
                 <option>&lt;=</option>
             </select>
-            <input type="text" placeholder="Filter value" aria-label="Filter value placeholder">
-            <button type="button" class="placeholder-button">Apply</button>
+            <input
+                id="filter-value-input"
+                type="text"
+                placeholder="Filter value"
+                aria-label="Filter value"
+            >
+            <div class="toolbar-actions">
+                <button id="apply-query-button" type="button" class="placeholder-button">Apply</button>
+                <button id="clear-query-state-button" type="button" class="placeholder-button secondary-button">Clear</button>
+            </div>
         </section>
 
         <section id="applied-queries-area" class="toolbar-group tags-row">
             <h2 class="group-title">Applied Queries</h2>
-            <div id="applied-query-tags">
-                <span class="query-tag">status:active</span>
-                <span class="query-tag">type:block</span>
-            </div>
+            <p id="applied-query-count" class="toolbar-feedback">0 applied</p>
+            <div id="applied-query-tags" aria-live="polite"></div>
+            <p id="applied-query-empty" class="toolbar-feedback">No applied queries</p>
         </section>
     </header>
 

--- a/graph_explorer/static/css/graph_explorer.css
+++ b/graph_explorer/static/css/graph_explorer.css
@@ -73,19 +73,59 @@ body {
     color: var(--muted);
 }
 
+.toolbar-feedback {
+    margin: 0;
+    font-size: 0.8rem;
+    color: var(--muted);
+}
+
+.toolbar-actions {
+    display: flex;
+    gap: 0.4rem;
+}
+
+.secondary-button {
+    background: #f5f8fb;
+}
+
 .tags-row #applied-query-tags {
     display: flex;
     flex-wrap: wrap;
     gap: 0.4rem;
+    min-height: 1.85rem;
 }
 
 .query-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
     border: 1px solid #bfd2ea;
     background: #eaf3ff;
     color: #19467d;
     border-radius: 999px;
-    padding: 0.2rem 0.55rem;
+    padding: 0.2rem 0.3rem 0.2rem 0.55rem;
     font-size: 0.8rem;
+}
+
+.query-tag-label {
+    line-height: 1.2;
+}
+
+.query-tag-remove {
+    border: 1px solid #9ab9dd;
+    border-radius: 999px;
+    width: 1.1rem;
+    height: 1.1rem;
+    padding: 0;
+    font-size: 0.72rem;
+    line-height: 1;
+    color: #1a4f8d;
+    background: #ffffff;
+    cursor: pointer;
+}
+
+.query-tag-remove:hover {
+    background: #dbeafc;
 }
 
 .sidebar {

--- a/graph_explorer/static/js/app.js
+++ b/graph_explorer/static/js/app.js
@@ -5,11 +5,20 @@
     // TODO: improve focus synchronization behavior across Main/Tree/Bird interactions.
     // TODO: replace mock data state with platform/API integration payloads.
     const EMPTY_GRAPH = { nodes: [], edges: [] };
+    const DEFAULT_FILTER_OPERATOR = "==";
 
     const state = {
         activeVisualizer: "simple",
         selectedNodeId: null,
-        graph: EMPTY_GRAPH
+        graph: EMPTY_GRAPH,
+        queryUI: {
+            searchText: "",
+            filterAttribute: "",
+            filterOperator: DEFAULT_FILTER_OPERATOR,
+            filterValue: "",
+            appliedChips: [],
+            nextChipId: 1
+        }
     };
 
     function isValidGraphShape(graph) {
@@ -145,6 +154,207 @@
         }
         state.activeVisualizer = mode;
         renderAll();
+    }
+
+    function getToolbarElements() {
+        return {
+            searchInput: document.getElementById("search-input"),
+            filterAttributeInput: document.getElementById("filter-attribute-input"),
+            filterOperatorSelect: document.getElementById("filter-operator-select"),
+            filterValueInput: document.getElementById("filter-value-input"),
+            applyQueryButton: document.getElementById("apply-query-button"),
+            clearQueryButton: document.getElementById("clear-query-state-button"),
+            appliedQueryTags: document.getElementById("applied-query-tags"),
+            appliedQueryCount: document.getElementById("applied-query-count"),
+            appliedQueryEmpty: document.getElementById("applied-query-empty"),
+            searchPreview: document.getElementById("search-preview")
+        };
+    }
+
+    function createAppliedChip(label, type, payload) {
+        const chip = {
+            id: state.queryUI.nextChipId,
+            label: label,
+            type: type,
+            payload: payload
+        };
+        state.queryUI.nextChipId += 1;
+        return chip;
+    }
+
+    function renderAppliedChips() {
+        const refs = getToolbarElements();
+        const tags = refs.appliedQueryTags;
+        if (!tags) {
+            return;
+        }
+
+        tags.innerHTML = "";
+        const chips = state.queryUI.appliedChips;
+
+        if (!chips.length) {
+            if (refs.appliedQueryEmpty) {
+                refs.appliedQueryEmpty.style.display = "";
+            }
+            return;
+        }
+
+        if (refs.appliedQueryEmpty) {
+            refs.appliedQueryEmpty.style.display = "none";
+        }
+
+        chips.forEach(function (chip) {
+            const chipEl = document.createElement("span");
+            chipEl.className = "query-tag";
+
+            const labelEl = document.createElement("span");
+            labelEl.className = "query-tag-label";
+            labelEl.textContent = chip.label;
+
+            const removeButton = document.createElement("button");
+            removeButton.type = "button";
+            removeButton.className = "query-tag-remove";
+            removeButton.setAttribute("data-chip-id", String(chip.id));
+            removeButton.setAttribute("aria-label", `Remove query: ${chip.label}`);
+            removeButton.textContent = "x";
+
+            chipEl.appendChild(labelEl);
+            chipEl.appendChild(removeButton);
+            tags.appendChild(chipEl);
+        });
+    }
+
+    function renderToolbarState() {
+        const refs = getToolbarElements();
+        const chipCount = state.queryUI.appliedChips.length;
+        const searchText = state.queryUI.searchText.trim();
+
+        if (refs.searchInput && refs.searchInput.value !== state.queryUI.searchText) {
+            refs.searchInput.value = state.queryUI.searchText;
+        }
+        if (refs.filterAttributeInput && refs.filterAttributeInput.value !== state.queryUI.filterAttribute) {
+            refs.filterAttributeInput.value = state.queryUI.filterAttribute;
+        }
+        if (refs.filterOperatorSelect && refs.filterOperatorSelect.value !== state.queryUI.filterOperator) {
+            refs.filterOperatorSelect.value = state.queryUI.filterOperator;
+        }
+        if (refs.filterValueInput && refs.filterValueInput.value !== state.queryUI.filterValue) {
+            refs.filterValueInput.value = state.queryUI.filterValue;
+        }
+
+        if (refs.appliedQueryCount) {
+            refs.appliedQueryCount.textContent = `${chipCount} applied`;
+        }
+        if (refs.searchPreview) {
+            refs.searchPreview.textContent = searchText ? `Current search: ${searchText}` : "Current search: none";
+        }
+
+        renderAppliedChips();
+    }
+
+    function removeAppliedChip(chipId) {
+        const targetId = String(chipId);
+        state.queryUI.appliedChips = state.queryUI.appliedChips.filter(function (chip) {
+            return String(chip.id) !== targetId;
+        });
+        renderToolbarState();
+    }
+
+    function handleApplyQuery() {
+        const searchText = state.queryUI.searchText.trim();
+        const attribute = state.queryUI.filterAttribute.trim();
+        const operator = state.queryUI.filterOperator.trim();
+        const value = state.queryUI.filterValue.trim();
+        const chipsToAdd = [];
+
+        if (searchText) {
+            chipsToAdd.push(createAppliedChip(`search: ${searchText}`, "search", { searchText: searchText }));
+        }
+
+        if (attribute && operator && value) {
+            chipsToAdd.push(createAppliedChip(`${attribute} ${operator} ${value}`, "filter", {
+                attribute: attribute,
+                operator: operator,
+                value: value
+            }));
+        }
+
+        if (!chipsToAdd.length) {
+            renderToolbarState();
+            return;
+        }
+
+        state.queryUI.appliedChips = state.queryUI.appliedChips.concat(chipsToAdd);
+
+        // TODO: send query/filter payload to backend and rerender filtered subgraph.
+        renderToolbarState();
+    }
+
+    function resetQueryFilterState() {
+        state.queryUI.searchText = "";
+        state.queryUI.filterAttribute = "";
+        state.queryUI.filterOperator = DEFAULT_FILTER_OPERATOR;
+        state.queryUI.filterValue = "";
+        state.queryUI.appliedChips = [];
+        state.queryUI.nextChipId = 1;
+
+        // TODO: when backend filtering is integrated, clear server-side query/filter state too.
+        renderToolbarState();
+    }
+
+    function bindToolbarControls() {
+        const refs = getToolbarElements();
+        if (!refs.searchInput || !refs.filterAttributeInput || !refs.filterOperatorSelect || !refs.filterValueInput) {
+            return;
+        }
+
+        refs.searchInput.addEventListener("input", function (event) {
+            state.queryUI.searchText = event.target.value;
+            renderToolbarState();
+        });
+
+        refs.filterAttributeInput.addEventListener("input", function (event) {
+            state.queryUI.filterAttribute = event.target.value;
+        });
+
+        refs.filterOperatorSelect.addEventListener("change", function (event) {
+            state.queryUI.filterOperator = event.target.value;
+        });
+
+        refs.filterValueInput.addEventListener("input", function (event) {
+            state.queryUI.filterValue = event.target.value;
+        });
+
+        if (refs.applyQueryButton) {
+            refs.applyQueryButton.addEventListener("click", function () {
+                handleApplyQuery();
+            });
+        }
+
+        if (refs.clearQueryButton) {
+            refs.clearQueryButton.addEventListener("click", function () {
+                resetQueryFilterState();
+            });
+        }
+
+        if (refs.appliedQueryTags) {
+            refs.appliedQueryTags.addEventListener("click", function (event) {
+                const target = event.target;
+                if (!target || !target.matches("[data-chip-id]")) {
+                    return;
+                }
+                removeAppliedChip(target.getAttribute("data-chip-id"));
+            });
+        }
+
+        [refs.searchInput, refs.filterAttributeInput, refs.filterValueInput].forEach(function (input) {
+            input.addEventListener("keydown", function (event) {
+                if (event.key === "Enter") {
+                    event.preventDefault();
+                    handleApplyQuery();
+                }
+            });
+        });
     }
 
     function bindMainNodeCardClicks(mainView) {
@@ -306,12 +516,14 @@
     function renderAll() {
         syncSelectedNode();
         renderUIState();
+        renderToolbarState();
         renderMainView();
         renderTreeView();
         renderBirdView();
     }
 
     document.addEventListener("DOMContentLoaded", function () {
+        bindToolbarControls();
         bindVisualizerTabClicks();
         renderAll();
         loadGraphData();


### PR DESCRIPTION
Closes #21

Implemented frontend-only query/filter UI state and interactive "Applied queries" chips in `graph_explorer`.

Included:
- frontend state for search and filter form fields
- apply action for adding query/filter chips
- per-chip remove action
- clear/reset toolbar UI state
- toolbar UI feedback (chips/empty state)
- preserved existing Main/Tree/Bird mock rendering and selection behavior

Not included:
- backend search/filter logic
- graph filtering/subgraph generation
- plugin/platform integration