### PR TITLE
M2: Implement console panel UI skeleton with input, output and history

### DIFF
--- a/graph_explorer/explorer/templates/explorer/index.html
+++ b/graph_explorer/explorer/templates/explorer/index.html
@@ -82,8 +82,30 @@
 
         <section id="console-panel" class="panel">
             <h2 class="panel-title">Console</h2>
-            <div class="panel-body placeholder-box render-surface">
-                TODO: future command input and execution controls.
+            <div id="console-panel-body" class="panel-body console-panel-body">
+                <div id="console-input-row" class="console-input-row">
+                    <input
+                        id="console-command-input"
+                        class="console-command-input"
+                        type="text"
+                        placeholder="Enter command (frontend-only placeholder)"
+                        aria-label="Console command input"
+                    >
+                    <button id="console-run-button" type="button" class="placeholder-button">Run</button>
+                    <button id="console-clear-button" type="button" class="placeholder-button secondary-button">Clear</button>
+                </div>
+
+                <section class="console-section" aria-label="Console output">
+                    <h3 class="console-section-title">Output</h3>
+                    <div id="console-output" class="console-output" aria-live="polite"></div>
+                    <p id="console-output-empty" class="empty-note">No console output yet.</p>
+                </section>
+
+                <section class="console-section" aria-label="Console history">
+                    <h3 class="console-section-title">History</h3>
+                    <ol id="console-history-list" class="console-history-list"></ol>
+                    <p id="console-history-empty" class="empty-note">No command history yet.</p>
+                </section>
             </div>
         </section>
     </aside>

--- a/graph_explorer/static/css/graph_explorer.css
+++ b/graph_explorer/static/css/graph_explorer.css
@@ -183,6 +183,79 @@ body {
     color: var(--muted);
 }
 
+.console-panel-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+    min-height: 0;
+}
+
+.console-input-row {
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    gap: 0.4rem;
+}
+
+.console-command-input {
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 0.45rem 0.55rem;
+    font-size: 0.86rem;
+    min-width: 0;
+}
+
+.console-section {
+    border: 1px solid #d9e2ec;
+    border-radius: 6px;
+    background: #f8fafc;
+    padding: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.console-section-title {
+    margin: 0;
+    font-size: 0.78rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: #526476;
+}
+
+.console-output,
+.console-history-list {
+    margin: 0;
+    padding: 0.35rem;
+    border: 1px solid #d8e0ea;
+    border-radius: 4px;
+    background: #ffffff;
+    max-height: 120px;
+    overflow: auto;
+}
+
+.console-output-line {
+    margin: 0;
+    font-family: "Consolas", "Courier New", monospace;
+    font-size: 0.8rem;
+    line-height: 1.35;
+    color: #203244;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.console-history-list {
+    padding-left: 1.5rem;
+}
+
+.console-history-item {
+    font-family: "Consolas", "Courier New", monospace;
+    font-size: 0.8rem;
+    color: #2c4054;
+    margin: 0.12rem 0;
+    word-break: break-word;
+}
+
 .panel-body {
     flex: 1;
     min-height: 0;
@@ -325,5 +398,9 @@ body {
     .sidebar {
         grid-template-columns: 1fr;
         grid-template-rows: auto auto auto auto;
+    }
+
+    .console-input-row {
+        grid-template-columns: 1fr;
     }
 }

--- a/graph_explorer/static/js/app.js
+++ b/graph_explorer/static/js/app.js
@@ -6,6 +6,7 @@
     // TODO: replace mock data state with platform/API integration payloads.
     const EMPTY_GRAPH = { nodes: [], edges: [] };
     const DEFAULT_FILTER_OPERATOR = "==";
+    const CONSOLE_PLACEHOLDER_OUTPUT = "Command execution is not implemented yet (frontend-only placeholder).";
 
     const state = {
         activeVisualizer: "simple",
@@ -18,6 +19,13 @@
             filterValue: "",
             appliedChips: [],
             nextChipId: 1
+        },
+        consoleUI: {
+            currentInput: "",
+            history: [],
+            outputLines: [],
+            maxHistory: 20,
+            maxOutputLines: 120
         }
     };
 
@@ -169,6 +177,123 @@
             appliedQueryEmpty: document.getElementById("applied-query-empty"),
             searchPreview: document.getElementById("search-preview")
         };
+    }
+
+    function getConsoleElements() {
+        return {
+            commandInput: document.getElementById("console-command-input"),
+            runButton: document.getElementById("console-run-button"),
+            clearButton: document.getElementById("console-clear-button"),
+            output: document.getElementById("console-output"),
+            outputEmpty: document.getElementById("console-output-empty"),
+            historyList: document.getElementById("console-history-list"),
+            historyEmpty: document.getElementById("console-history-empty")
+        };
+    }
+
+    function pushConsoleHistory(command) {
+        state.consoleUI.history.push(command);
+        if (state.consoleUI.history.length > state.consoleUI.maxHistory) {
+            state.consoleUI.history = state.consoleUI.history.slice(-state.consoleUI.maxHistory);
+        }
+    }
+
+    function pushConsoleOutputLine(line) {
+        state.consoleUI.outputLines.push(line);
+        if (state.consoleUI.outputLines.length > state.consoleUI.maxOutputLines) {
+            state.consoleUI.outputLines = state.consoleUI.outputLines.slice(-state.consoleUI.maxOutputLines);
+        }
+    }
+
+    function renderConsole() {
+        const refs = getConsoleElements();
+
+        if (refs.commandInput && refs.commandInput.value !== state.consoleUI.currentInput) {
+            refs.commandInput.value = state.consoleUI.currentInput;
+        }
+
+        if (refs.output) {
+            refs.output.innerHTML = "";
+            state.consoleUI.outputLines.forEach(function (line) {
+                const lineEl = document.createElement("p");
+                lineEl.className = "console-output-line";
+                lineEl.textContent = line;
+                refs.output.appendChild(lineEl);
+            });
+        }
+
+        if (refs.outputEmpty) {
+            refs.outputEmpty.style.display = state.consoleUI.outputLines.length ? "none" : "";
+        }
+
+        if (refs.historyList) {
+            refs.historyList.innerHTML = "";
+            state.consoleUI.history.slice().reverse().forEach(function (command) {
+                const itemEl = document.createElement("li");
+                itemEl.className = "console-history-item";
+                itemEl.textContent = command;
+                refs.historyList.appendChild(itemEl);
+            });
+        }
+
+        if (refs.historyEmpty) {
+            refs.historyEmpty.style.display = state.consoleUI.history.length ? "none" : "";
+        }
+    }
+
+    function handleRunConsoleCommand() {
+        const command = state.consoleUI.currentInput.trim();
+        if (!command) {
+            return;
+        }
+
+        pushConsoleHistory(command);
+        pushConsoleOutputLine(`> ${command}`);
+        pushConsoleOutputLine(CONSOLE_PLACEHOLDER_OUTPUT);
+
+        // TODO: parse and validate supported console commands.
+        // TODO: connect console commands to backend/platform endpoint.
+        // TODO: map command responses to corresponding console UI updates.
+
+        state.consoleUI.currentInput = "";
+        renderConsole();
+    }
+
+    function clearConsoleState() {
+        state.consoleUI.currentInput = "";
+        state.consoleUI.history = [];
+        state.consoleUI.outputLines = [];
+        renderConsole();
+    }
+
+    function bindConsoleControls() {
+        const refs = getConsoleElements();
+        if (!refs.commandInput) {
+            return;
+        }
+
+        refs.commandInput.addEventListener("input", function (event) {
+            state.consoleUI.currentInput = event.target.value;
+        });
+
+        refs.commandInput.addEventListener("keydown", function (event) {
+            if (event.key === "Enter") {
+                event.preventDefault();
+                handleRunConsoleCommand();
+            }
+        });
+
+        if (refs.runButton) {
+            refs.runButton.addEventListener("click", function () {
+                handleRunConsoleCommand();
+            });
+        }
+
+        if (refs.clearButton) {
+            refs.clearButton.addEventListener("click", function () {
+                clearConsoleState();
+            });
+        }
     }
 
     function createAppliedChip(label, type, payload) {
@@ -517,6 +642,7 @@
         syncSelectedNode();
         renderUIState();
         renderToolbarState();
+        renderConsole();
         renderMainView();
         renderTreeView();
         renderBirdView();
@@ -524,6 +650,7 @@
 
     document.addEventListener("DOMContentLoaded", function () {
         bindToolbarControls();
+        bindConsoleControls();
         bindVisualizerTabClicks();
         renderAll();
         loadGraphData();


### PR DESCRIPTION
Closes #23

Implemented a frontend-only Console/CLI panel UI skeleton in `graph_explorer`.

Included:
- command input field
- Run button (UI action only)
- console output/log area
- command history list (frontend-only placeholder)
- frontend console state and basic interactions
- optional clear console action (if implemented)

Not included:
- command parsing/execution logic
- backend/platform integration for console commands
- real CLI command handling