### PR TITLE
M2: Add loading, error and retry UI states for graph fetch

### DIFF
--- a/graph_explorer/explorer/templates/explorer/index.html
+++ b/graph_explorer/explorer/templates/explorer/index.html
@@ -113,6 +113,10 @@
     <main id="main-content" class="main-content">
         <section id="main-view-panel" class="panel main-panel">
             <h2 class="panel-title">Main View</h2>
+            <div id="graph-fetch-status" class="graph-fetch-status is-hidden" role="status" aria-live="polite">
+                <p id="graph-fetch-status-message" class="graph-fetch-status-message"></p>
+                <button id="graph-fetch-retry-button" type="button" class="placeholder-button secondary-button" hidden>Retry</button>
+            </div>
             <div id="main-view-content" class="panel-body placeholder-box render-surface">
                 {{ placeholder_message }}
                 <p>TODO: plugin render output will be injected here</p>

--- a/graph_explorer/static/css/graph_explorer.css
+++ b/graph_explorer/static/css/graph_explorer.css
@@ -278,6 +278,52 @@ body {
     min-height: 420px;
 }
 
+.graph-fetch-status {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.6rem;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    background: #f7fbff;
+    color: #35506b;
+    padding: 0.45rem 0.55rem;
+}
+
+.graph-fetch-status.is-hidden {
+    display: none !important;
+}
+
+.graph-fetch-status-message {
+    margin: 0;
+    font-size: 0.83rem;
+    line-height: 1.3;
+}
+
+.graph-fetch-status.is-idle {
+    border-color: #d2dce7;
+    background: #f7fbff;
+    color: #35506b;
+}
+
+.graph-fetch-status.is-loading {
+    border-color: #bdd2e8;
+    background: #edf5ff;
+    color: #1d4f83;
+}
+
+.graph-fetch-status.is-success {
+    border-color: #bfdcc8;
+    background: #eefaf2;
+    color: #1f662f;
+}
+
+.graph-fetch-status.is-error {
+    border-color: #e3b9bd;
+    background: #fff1f2;
+    color: #8f2a32;
+}
+
 .render-surface {
     display: block;
     text-align: left;


### PR DESCRIPTION
Closes #27

Improved `graph_explorer` graph fetch UX with explicit loading/error/retry UI states.

Included:
- loading state while fetching graph data
- error state with visible Retry action
- success state after successful fetch
- success status auto-hide after 5 seconds
- full status box hide when status becomes inactive/idle (no empty status container)
- fetch payload validation and safer frontend error handling

Behavior notes:
- no fallback graph is injected on fetch failure
- error status remains visible until retry / next fetch
- existing Main/Tree/Bird rendering and frontend interactions remain intact

Not included:
- real plugin/platform integration
- backend search/filter execution
- graph processing logic changes