### PR TITLE
M2: Load graph from file and render visualizers with synced selection

### DIFF
--- a/graph_explorer/explorer/templates/explorer/base.html
+++ b/graph_explorer/explorer/templates/explorer/base.html
@@ -9,7 +9,6 @@
 </head>
 <body>
     {% block content %}{% endblock %}
-    <script src="{% static 'js/mock_graph.js' %}"></script>
     <script src="{% static 'js/app.js' %}"></script>
     {% block extra_scripts %}{% endblock %}
 </body>

--- a/graph_explorer/explorer/templates/explorer/index.html
+++ b/graph_explorer/explorer/templates/explorer/index.html
@@ -3,53 +3,67 @@
 {% block content %}
 <div id="graph-explorer-layout" class="app-shell">
     <header id="top-toolbar" class="toolbar">
-        <section id="file-input-area" class="toolbar-group">
-            <h2 class="group-title">File Input</h2>
-            <button type="button" class="placeholder-button">Select File</button>
-            <span class="placeholder-text">No file selected</span>
-        </section>
+        <div class="tools-row">
+            <section id="file-input-area" class="toolbar-group compact-group toolbar-column">
+                <h2 class="group-title">File</h2>
+                <div class="file-row">
+                    <input
+                        id="graph-file-input"
+                        type="file"
+                        accept=".json,.csv"
+                        aria-label="Upload graph file"
+                    >
+                    <button id="load-graph-button" type="button" class="placeholder-button">Load</button>
+                </div>
+                <div class="toolbar-inline-feedback">
+                    <span id="selected-file-name" class="placeholder-text">No file selected</span>
+                    <p id="file-load-status" class="toolbar-feedback">Select a JSON or CSV file to load.</p>
+                </div>
+            </section>
 
-        <section id="search-area" class="toolbar-group">
-            <h2 class="group-title">Search</h2>
-            <input
-                id="search-input"
-                type="text"
-                placeholder="Search nodes or edges"
-                aria-label="Search text"
-            >
-            <p id="search-preview" class="toolbar-feedback">Current search: none</p>
-        </section>
+            <section id="search-area" class="toolbar-group compact-group toolbar-column">
+                <h2 class="group-title">Search</h2>
+                <input
+                    id="search-input"
+                    type="text"
+                    placeholder="Search nodes or edges"
+                    aria-label="Search text"
+                >
+                <p id="search-preview" class="toolbar-feedback">Current search: none</p>
+            </section>
 
-        <section id="filter-area" class="toolbar-group">
-            <h2 class="group-title">Filters</h2>
-            <input
-                id="filter-attribute-input"
-                type="text"
-                placeholder="Filter key"
-                aria-label="Filter attribute"
-            >
-            <select id="filter-operator-select" aria-label="Filter operator">
-                <option>==</option>
-                <option>!=</option>
-                <option>&gt;</option>
-                <option>&gt;=</option>
-                <option>&lt;</option>
-                <option>&lt;=</option>
-            </select>
-            <input
-                id="filter-value-input"
-                type="text"
-                placeholder="Filter value"
-                aria-label="Filter value"
-            >
-            <div class="toolbar-actions">
-                <button id="apply-query-button" type="button" class="placeholder-button">Apply</button>
-                <button id="clear-query-state-button" type="button" class="placeholder-button secondary-button">Clear</button>
-            </div>
-        </section>
+            <section id="filter-area" class="toolbar-group compact-group toolbar-column">
+                <h2 class="group-title">Filters</h2>
+                <div class="filter-row">
+                    <input
+                        id="filter-attribute-input"
+                        type="text"
+                        placeholder="Filter key"
+                        aria-label="Filter attribute"
+                    >
+                    <select id="filter-operator-select" aria-label="Filter operator">
+                        <option>==</option>
+                        <option>!=</option>
+                        <option>&gt;</option>
+                        <option>&gt;=</option>
+                        <option>&lt;</option>
+                        <option>&lt;=</option>
+                    </select>
+                    <input
+                        id="filter-value-input"
+                        type="text"
+                        placeholder="Filter value"
+                        aria-label="Filter value"
+                    >
+                    <div class="toolbar-actions">
+                        <button id="apply-query-button" type="button" class="placeholder-button">Apply</button>
+                        <button id="clear-query-state-button" type="button" class="placeholder-button secondary-button">Clear</button>
+                    </div>
+                </div>
+            </section>
+        </div>
 
-        <section id="applied-queries-area" class="toolbar-group tags-row">
-            <h2 class="group-title">Applied Queries</h2>
+        <section id="applied-queries-area" class="toolbar-group tags-row chips-row">
             <p id="applied-query-count" class="toolbar-feedback">0 applied</p>
             <div id="applied-query-tags" aria-live="polite"></div>
             <p id="applied-query-empty" class="toolbar-feedback">No applied queries</p>
@@ -72,45 +86,12 @@
 
         <section id="tree-view-panel" class="panel">
             <h2 class="panel-title">Tree View</h2>
-            <div id="tree-view-content" class="panel-body placeholder-box render-surface">
-                Tree view placeholder
-            </div>
+            <div id="tree-view-content" class="panel-body render-surface view-scrollable"></div>
         </section>
 
         <section id="bird-view-panel" class="panel">
             <h2 class="panel-title">Bird View</h2>
-            <div id="bird-view-content" class="panel-body placeholder-box render-surface">
-                Bird view placeholder
-            </div>
-        </section>
-
-        <section id="console-panel" class="panel">
-            <h2 class="panel-title">Console</h2>
-            <div id="console-panel-body" class="panel-body console-panel-body">
-                <div id="console-input-row" class="console-input-row">
-                    <input
-                        id="console-command-input"
-                        class="console-command-input"
-                        type="text"
-                        placeholder="Enter command (frontend-only placeholder)"
-                        aria-label="Console command input"
-                    >
-                    <button id="console-run-button" type="button" class="placeholder-button">Run</button>
-                    <button id="console-clear-button" type="button" class="placeholder-button secondary-button">Clear</button>
-                </div>
-
-                <section class="console-section" aria-label="Console output">
-                    <h3 class="console-section-title">Output</h3>
-                    <div id="console-output" class="console-output" aria-live="polite"></div>
-                    <p id="console-output-empty" class="empty-note">No console output yet.</p>
-                </section>
-
-                <section class="console-section" aria-label="Console history">
-                    <h3 class="console-section-title">History</h3>
-                    <ol id="console-history-list" class="console-history-list"></ol>
-                    <p id="console-history-empty" class="empty-note">No command history yet.</p>
-                </section>
-            </div>
+            <div id="bird-view-content" class="panel-body render-surface view-scrollable"></div>
         </section>
     </aside>
 
@@ -121,16 +102,38 @@
                 <p id="graph-fetch-status-message" class="graph-fetch-status-message"></p>
                 <button id="graph-fetch-retry-button" type="button" class="placeholder-button secondary-button" hidden>Retry</button>
             </div>
-            <div id="main-view-content" class="panel-body placeholder-box render-surface">
-                <p id="main-view-render-status" class="view-meta"></p>
+            <div id="main-view-content" class="panel-body render-surface">
+                <p id="main-view-render-status" class="view-meta" hidden></p>
                 <p id="main-view-render-error" class="empty-note" hidden></p>
-                <div id="main-view-visualizer-output" class="main-view-visualizer-output" hidden></div>
-                <div id="main-view-fallback-content" class="main-view-fallback-content">
-                    {{ placeholder_message }}
-                    <p>TODO: plugin render output will be injected here</p>
-                </div>
+                <div id="main-view-visualizer-output" class="main-view-output"></div>
             </div>
         </section>
     </main>
+
+    <section id="console-dock" class="console-dock is-collapsed" aria-label="Console dock">
+        <header class="console-dock-header">
+            <h2 class="console-dock-title">Console</h2>
+            <button id="console-toggle-button" type="button" class="placeholder-button secondary-button">Open</button>
+        </header>
+        <div id="console-dock-body" class="console-dock-body">
+            <div id="console-input-row" class="console-input-row">
+                <input
+                    id="console-command-input"
+                    class="console-command-input"
+                    type="text"
+                    placeholder="Enter command (frontend-only placeholder)"
+                    aria-label="Console command input"
+                >
+                <button id="console-run-button" type="button" class="placeholder-button">Run</button>
+                <button id="console-clear-button" type="button" class="placeholder-button secondary-button">Clear</button>
+            </div>
+
+            <section class="console-section console-output-section" aria-label="Console output">
+                <h3 class="console-section-title">Output</h3>
+                <div id="console-output" class="console-output" aria-live="polite"></div>
+                <p id="console-output-empty" class="empty-note">No console output yet.</p>
+            </section>
+        </div>
+    </section>
 </div>
 {% endblock %}

--- a/graph_explorer/explorer/urls.py
+++ b/graph_explorer/explorer/urls.py
@@ -7,5 +7,6 @@ app_name = "explorer"
 urlpatterns = [
     path("", views.index, name="index"),
     path("api/mock-graph/", views.mock_graph_api, name="mock-graph-api"),
+    path("api/graph/load", views.load_graph_api, name="graph-load-api"),
     path("api/render/", views.render_visualizer_api, name="render-visualizer-api"),
 ]

--- a/graph_explorer/explorer/views.py
+++ b/graph_explorer/explorer/views.py
@@ -1,8 +1,15 @@
+import os
+import logging
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from uuid import uuid4
 from html import escape as escape_html
 
+from django.core.files.uploadedfile import UploadedFile
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import render
-from django.views.decorators.http import require_GET
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_GET, require_POST
 
 try:
     from graph_api.model.edge import Edge
@@ -32,6 +39,22 @@ except Exception as exc:  # pragma: no cover - import failure path is runtime/en
 else:
     BLOCK_VISUALIZER_IMPORT_ERROR = None
 
+try:
+    from datasource_json_plugin.plugin import JsonDatasourcePlugin
+except Exception as exc:  # pragma: no cover - import failure path is runtime/environment dependent
+    JsonDatasourcePlugin = None  # type: ignore[assignment]
+    JSON_DATASOURCE_IMPORT_ERROR = exc
+else:
+    JSON_DATASOURCE_IMPORT_ERROR = None
+
+try:
+    from datasource_csv_plugin.plugin import CsvDatasourcePlugin
+except Exception as exc:  # pragma: no cover - import failure path is runtime/environment dependent
+    CsvDatasourcePlugin = None  # type: ignore[assignment]
+    CSV_DATASOURCE_IMPORT_ERROR = exc
+else:
+    CSV_DATASOURCE_IMPORT_ERROR = None
+
 
 MOCK_GRAPH_DATA = {
     "nodes": [
@@ -44,18 +67,111 @@ MOCK_GRAPH_DATA = {
         {"id": "e2", "source": "n2", "target": "n3"},
     ],
 }
+ACTIVE_GRAPHS: dict[str, object] = {}
+LOGGER = logging.getLogger(__name__)
+
+
+def _json_error(message: str, status: int) -> JsonResponse:
+    return JsonResponse({"ok": False, "error": message}, status=status)
+
+
+def _build_datasource_map() -> dict[str, tuple[str, object | None, Exception | None]]:
+    return {
+        ".json": ("json", JsonDatasourcePlugin, JSON_DATASOURCE_IMPORT_ERROR),
+        ".csv": ("csv", CsvDatasourcePlugin, CSV_DATASOURCE_IMPORT_ERROR),
+    }
+
+
+def _load_graph_from_upload(uploaded_file: UploadedFile, suffix: str, datasource_cls: object) -> Graph:
+    temp_path: str | None = None
+    try:
+        with NamedTemporaryFile(delete=False, suffix=suffix) as temp_file:
+            temp_path = temp_file.name
+            for chunk in uploaded_file.chunks():
+                temp_file.write(chunk)
+
+        datasource = datasource_cls()
+        return datasource.load_graph(temp_path)
+    finally:
+        if temp_path and os.path.exists(temp_path):
+            try:
+                os.remove(temp_path)
+            except OSError:
+                pass
+
+
+def _store_active_graph_id_in_session(request: HttpRequest, graph_id: str) -> None:
+    try:
+        request.session["active_graph_id"] = graph_id
+        request.session.save()
+    except Exception:
+        LOGGER.warning("Unable to persist active_graph_id in session.")
+        try:
+            request.session.modified = False
+        except Exception:
+            pass
 
 
 def index(request: HttpRequest) -> HttpResponse:
     context = {
         "page_title": "Graph Explorer",
-        "placeholder_message": "Main graph rendering placeholder",
     }
     return render(request, "explorer/index.html", context)
 
 
 def mock_graph_api(request: HttpRequest) -> JsonResponse:
     return JsonResponse(MOCK_GRAPH_DATA)
+
+
+@csrf_exempt
+@require_POST
+def load_graph_api(request: HttpRequest) -> JsonResponse:
+    uploaded_file = request.FILES.get("file")
+    if uploaded_file is None:
+        return _json_error("missing file", status=400)
+
+    filename = str(uploaded_file.name or "uploaded-file")
+    extension = Path(filename).suffix.lower()
+    datasource_map = _build_datasource_map()
+
+    if extension not in datasource_map:
+        return _json_error("Unsupported file extension. Allowed extensions are .json and .csv.", status=400)
+
+    source_name, datasource_cls, import_error = datasource_map[extension]
+    if datasource_cls is None:
+        detail = f" ({import_error})" if import_error else ""
+        return _json_error(f"The '{source_name}' datasource plugin is not available{detail}", status=501)
+
+    try:
+        try:
+            graph = _load_graph_from_upload(uploaded_file=uploaded_file, suffix=extension, datasource_cls=datasource_cls)
+        except Exception as exc:
+            return _json_error(f"Failed to parse '{filename}' as {source_name}: {exc}", status=400)
+
+        graph_id = str(uuid4())
+        ACTIVE_GRAPHS[graph_id] = graph
+        _store_active_graph_id_in_session(request, graph_id)
+
+        graph_payload = graph.to_dict()
+        nodes = graph_payload.get("nodes", [])
+        edges = graph_payload.get("edges", [])
+        return JsonResponse(
+            {
+                "ok": True,
+                "graph_id": graph_id,
+                "meta": {
+                    "node_count": len(nodes) if isinstance(nodes, list) else 0,
+                    "edge_count": len(edges) if isinstance(edges, list) else 0,
+                    "filename": filename,
+                    "source": source_name,
+                },
+                "graph": graph_payload,
+            },
+            status=200,
+        )
+    except Exception as exc:
+        LOGGER.exception("Unexpected graph load failure.")
+        return _json_error(f"Unexpected graph load failure: {exc}", status=500)
 
 
 def _html_response(title: str, message: str, status: int = 200) -> HttpResponse:
@@ -151,6 +267,22 @@ def render_visualizer_api(request: HttpRequest) -> HttpResponse:
     except ValueError as exc:
         return _html_response("Invalid directed flag", str(exc), status=400)
 
+    graph_id = request.GET.get("graph_id", "").strip()
+    if not graph_id:
+        return _html_response(
+            "Missing graph_id",
+            "Query parameter 'graph_id' is required.",
+            status=400,
+        )
+
+    graph = ACTIVE_GRAPHS.get(graph_id)
+    if graph is None:
+        return _html_response(
+            "Graph Not Found",
+            f"Graph '{graph_id}' was not found in the active graph store.",
+            status=404,
+        )
+
     if visualizer_id == "block" and BlockVisualizer is None:
         detail = f" ({BLOCK_VISUALIZER_IMPORT_ERROR})" if BLOCK_VISUALIZER_IMPORT_ERROR else ""
         return _html_response(
@@ -176,7 +308,11 @@ def render_visualizer_api(request: HttpRequest) -> HttpResponse:
         )
 
     try:
-        graph = _build_mock_graph(is_directed=is_directed)
+        if hasattr(graph, "directed"):
+            graph.directed = is_directed
+        for edge in getattr(graph, "edges", []):
+            if hasattr(edge, "directed"):
+                edge.directed = is_directed
         html = visualizer.render(graph)
     except Exception as exc:
         return _html_response(

--- a/graph_explorer/static/css/graph_explorer.css
+++ b/graph_explorer/static/css/graph_explorer.css
@@ -11,43 +11,68 @@
     box-sizing: border-box;
 }
 
+html,
+body {
+    height: 100%;
+}
+
 body {
     margin: 0;
     font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
     color: var(--text);
     background: linear-gradient(180deg, #eef2f6 0%, #f7fafc 100%);
+    overflow: hidden;
 }
 
 .app-shell {
+    height: 100vh;
     min-height: 100vh;
     padding: 1rem;
     display: grid;
     grid-template-columns: 320px 1fr;
     grid-template-rows: auto 1fr;
     gap: 1rem;
+    overflow: hidden;
 }
 
 .toolbar {
     grid-column: 1 / -1;
-    display: grid;
-    grid-template-columns: repeat(4, minmax(180px, 1fr));
-    gap: 0.75rem;
-    padding: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    padding: 0.55rem 0.7rem;
     border: 1px solid var(--line);
     border-radius: 8px;
     background: var(--panel-bg);
 }
 
+.tools-row {
+    display: grid;
+    grid-template-columns: minmax(260px, 1.35fr) minmax(210px, 1fr) minmax(380px, 1.9fr);
+    gap: 0.55rem;
+    align-items: start;
+}
+
 .toolbar-group {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.35rem;
     min-width: 0;
+}
+
+.compact-group {
+    gap: 0.25rem;
+}
+
+.toolbar-column {
+    display: grid;
+    grid-template-rows: auto auto auto;
+    align-content: start;
 }
 
 .group-title {
     margin: 0;
-    font-size: 0.8rem;
+    font-size: 0.74rem;
     font-weight: 700;
     text-transform: uppercase;
     color: var(--muted);
@@ -59,8 +84,8 @@ body {
 .placeholder-button {
     border: 1px solid var(--line);
     border-radius: 6px;
-    padding: 0.45rem 0.55rem;
-    font-size: 0.9rem;
+    padding: 0.32rem 0.45rem;
+    font-size: 0.84rem;
     background: #fff;
 }
 
@@ -69,30 +94,68 @@ body {
 }
 
 .placeholder-text {
-    font-size: 0.85rem;
+    font-size: 0.78rem;
     color: var(--muted);
 }
 
 .toolbar-feedback {
     margin: 0;
-    font-size: 0.8rem;
+    font-size: 0.76rem;
     color: var(--muted);
 }
 
 .toolbar-actions {
     display: flex;
-    gap: 0.4rem;
+    gap: 0.3rem;
+    justify-content: flex-end;
 }
 
 .secondary-button {
     background: #f5f8fb;
 }
 
+.file-row {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    min-height: 34px;
+}
+
+.file-row input[type="file"] {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.toolbar-inline-feedback {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    column-gap: 0.5rem;
+    row-gap: 0.12rem;
+}
+
+.filter-row {
+    display: grid;
+    grid-template-columns: minmax(130px, 2fr) minmax(70px, 0.85fr) minmax(130px, 2fr) auto;
+    gap: 0.35rem;
+    align-items: center;
+    min-height: 34px;
+}
+
+.chips-row {
+    border-top: 1px solid #e2e8f0;
+    padding-top: 0.35rem;
+}
+
 .tags-row #applied-query-tags {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.4rem;
-    min-height: 1.85rem;
+    gap: 0.3rem;
+    min-height: 1.35rem;
+}
+
+.chips-row #applied-query-count {
+    margin-bottom: 0.05rem;
 }
 
 .query-tag {
@@ -104,7 +167,7 @@ body {
     color: #19467d;
     border-radius: 999px;
     padding: 0.2rem 0.3rem 0.2rem 0.55rem;
-    font-size: 0.8rem;
+    font-size: 0.75rem;
 }
 
 .query-tag-label {
@@ -114,10 +177,10 @@ body {
 .query-tag-remove {
     border: 1px solid #9ab9dd;
     border-radius: 999px;
-    width: 1.1rem;
-    height: 1.1rem;
+    width: 1rem;
+    height: 1rem;
     padding: 0;
-    font-size: 0.72rem;
+    font-size: 0.66rem;
     line-height: 1;
     color: #1a4f8d;
     background: #ffffff;
@@ -129,13 +192,33 @@ body {
 }
 
 .sidebar {
-    display: grid;
-    grid-template-rows: auto 1fr 1fr auto;
+    display: flex;
+    flex-direction: column;
     gap: 0.75rem;
+    min-height: 0;
+    height: 100%;
+    overflow: hidden;
+}
+
+#visualizer-controls {
+    flex: 0 0 auto;
+}
+
+#tree-view-panel {
+    flex: 1 1 0;
+    min-height: 0;
+}
+
+#bird-view-panel {
+    flex: 0 0 170px;
+    min-height: 0;
 }
 
 .main-content {
     min-height: 0;
+    height: 100%;
+    display: flex;
+    overflow: hidden;
 }
 
 .panel {
@@ -247,8 +330,65 @@ body {
     border: 1px solid #d8e0ea;
     border-radius: 4px;
     background: #ffffff;
-    max-height: 120px;
+    max-height: 150px;
     overflow: auto;
+}
+
+.console-dock {
+    position: fixed;
+    right: 16px;
+    bottom: 16px;
+    width: min(380px, calc(100vw - 2rem));
+    max-height: 42vh;
+    z-index: 30;
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    background: #ffffff;
+    box-shadow: 0 10px 28px rgba(23, 36, 50, 0.22);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.console-dock-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.45rem;
+    padding: 0.35rem 0.45rem;
+    border-bottom: 1px solid #dce5ef;
+    background: #f2f7fc;
+}
+
+.console-dock-title {
+    margin: 0;
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: #344b63;
+    letter-spacing: 0.02em;
+}
+
+.console-dock-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    min-height: 0;
+    max-height: calc(42vh - 42px);
+    padding: 0.45rem;
+}
+
+.console-output-section {
+    flex: 1 1 auto;
+    min-height: 0;
+}
+
+.console-dock .console-output {
+    max-height: none;
+    height: 100%;
+}
+
+.console-dock.is-collapsed .console-dock-body {
+    display: none;
 }
 
 .console-output-line {
@@ -291,8 +431,9 @@ body {
 }
 
 .main-panel {
+    flex: 1 1 auto;
     height: 100%;
-    min-height: 420px;
+    min-height: 0;
 }
 
 .graph-fetch-status {
@@ -342,21 +483,21 @@ body {
 }
 
 .render-surface {
-    display: block;
+    display: flex;
+    flex-direction: column;
     text-align: left;
-    align-items: stretch;
-    justify-content: flex-start;
-    overflow: auto;
+    overflow: hidden;
+    min-height: 0;
 }
 
-.main-view-visualizer-output {
-    height: 320px;
-    min-height: 220px;
+.main-view-output {
+    flex: 1 1 auto;
+    min-height: 0;
+    width: 100%;
     border: 1px solid #c9d6e3;
     border-radius: 6px;
     background: #ffffff;
     overflow: hidden;
-    margin-bottom: 0.75rem;
 }
 
 #main-view-visualizer-iframe {
@@ -366,64 +507,22 @@ body {
     display: block;
 }
 
-.main-view-fallback-content {
-    margin-top: 0.15rem;
+.view-scrollable {
+    flex: 1 1 auto;
+    height: 100%;
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+    border: 1px solid #d8e2ec;
+    border-radius: 6px;
+    background: #f8fbff;
+    padding: 0.45rem;
 }
 
 .view-meta {
     margin: 0 0 0.4rem;
     font-size: 0.86rem;
     color: var(--muted);
-}
-
-.node-cards {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
-    gap: 0.55rem;
-    margin: 0.55rem 0 0.8rem;
-}
-
-.node-card {
-    border: 1px solid #c9d6e3;
-    background: #ffffff;
-    border-radius: 6px;
-    padding: 0.55rem;
-    text-align: left;
-    cursor: pointer;
-    color: var(--text);
-}
-
-.node-card:hover {
-    border-color: #86a8cd;
-    background: #f8fbff;
-}
-
-.node-card.selected {
-    border-color: var(--accent);
-    background: #eaf2fd;
-}
-
-.node-card-title {
-    margin: 0 0 0.35rem;
-    font-size: 0.88rem;
-    font-weight: 700;
-}
-
-.node-card-meta {
-    margin: 0.2rem 0;
-    font-size: 0.8rem;
-    color: #46586d;
-}
-
-.placeholder-list {
-    margin: 0;
-    padding-left: 1.1rem;
-}
-
-.placeholder-list li {
-    margin: 0.2rem 0;
-    font-size: 0.84rem;
-    color: #3e5168;
 }
 
 .tree-list {
@@ -433,16 +532,39 @@ body {
 }
 
 .tree-item {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.28rem 0.35rem;
+    display: block;
+    padding: 0.18rem 0;
     border-radius: 4px;
     font-size: 0.84rem;
 }
 
-.tree-item.selected {
+.tree-node-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    width: 100%;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    padding: 0.25rem 0.35rem;
+    text-align: left;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+}
+
+.tree-node-button:hover {
+    border-color: #bfd2ea;
+    background: #eef5ff;
+}
+
+.tree-item.selected .tree-node-button {
+    border-color: #b4cbeb;
     background: #eaf2fd;
+}
+
+.tree-item.selected {
+    border-radius: 4px;
     color: #0e3d74;
     font-weight: 700;
 }
@@ -452,17 +574,6 @@ body {
     color: var(--accent);
 }
 
-.visualizer-pill {
-    display: inline-block;
-    border: 1px solid #bfd2ea;
-    background: #eaf3ff;
-    color: #19467d;
-    border-radius: 999px;
-    padding: 0.05rem 0.45rem;
-    font-size: 0.78rem;
-    text-transform: lowercase;
-}
-
 .empty-note {
     margin: 0.3rem 0;
     font-size: 0.84rem;
@@ -470,21 +581,52 @@ body {
 }
 
 @media (max-width: 980px) {
+    body {
+        overflow: auto;
+    }
+
     .app-shell {
+        height: auto;
         grid-template-columns: 1fr;
         grid-template-rows: auto auto 1fr;
+        overflow: visible;
     }
 
     .toolbar {
+        gap: 0.6rem;
+    }
+
+    .tools-row {
+        grid-template-columns: 1fr;
+        align-items: stretch;
+    }
+
+    .filter-row {
         grid-template-columns: 1fr;
     }
 
     .sidebar {
+        display: grid;
         grid-template-columns: 1fr;
         grid-template-rows: auto auto auto auto;
+        height: auto;
+        overflow: visible;
+    }
+
+    #tree-view-panel,
+    #bird-view-panel {
+        min-height: 220px;
     }
 
     .console-input-row {
         grid-template-columns: 1fr;
+    }
+
+    .console-dock {
+        position: fixed;
+        right: 10px;
+        left: 10px;
+        width: auto;
+        max-height: 45vh;
     }
 }

--- a/graph_explorer/webapp/settings.py
+++ b/graph_explorer/webapp/settings.py
@@ -7,6 +7,8 @@ REPO_ROOT = BASE_DIR.parent
 for extra_path in (
     REPO_ROOT,
     REPO_ROOT / "api",
+    REPO_ROOT / "datasource_json",
+    REPO_ROOT / "datasource_csv",
     REPO_ROOT / "visualizer_simple",
     REPO_ROOT / "visualizer_block",
 ):

--- a/visualizer_block/visualizer_block_plugin/templates/block.html
+++ b/visualizer_block/visualizer_block_plugin/templates/block.html
@@ -3,6 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <style>
+        html, body { margin: 0; width: 100%; height: 100%; overflow: hidden; }
+        #viz-scroll { width: 100%; height: 100%; overflow: auto; background: #fafafa; }
+        #viz-svg { display: block; background: #fafafa; border: 1px solid #eee; }
         .block-container {
             border: 1px solid #333;
             background-color: #fff;
@@ -52,10 +55,17 @@
         /* Nice scroll for small elements */
         .scroll-active::-webkit-scrollbar { width: 4px; }
         .scroll-active::-webkit-scrollbar-thumb { background: #888; border-radius: 2px; }
+        foreignObject.gv-node { cursor: pointer; }
+        foreignObject.gv-node.selected .block-container {
+            outline: 3px solid #ff6a00;
+            outline-offset: -3px;
+            box-shadow: 0 0 0 2px rgba(255, 106, 0, 0.15);
+        }
     </style>
 </head>
 <body>
-    <svg width="{{ width }}" height="{{ height }}" style="background: #fafafa; border: 1px solid #eee;">
+    <div id="viz-scroll">
+    <svg id="viz-svg" width="{{ width }}" height="{{ height }}">
         <defs>
             {# Dodajemo malu marginu (+3) da strelica ne dodiruje samu ivicu teksta #}
             <marker id="arrowhead" markerWidth="10" markerHeight="7"
@@ -78,7 +88,9 @@
         {% for node in nodes %}
             {% set pos = positions[node.node_id] %}
             <foreignObject x="{{ pos.top_x }}" y="{{ pos.top_y }}"
-                           width="{{ block_w }}" height="{{ block_h }}">
+                           width="{{ block_w }}" height="{{ block_h }}"
+                           class="gv-node"
+                           data-node-id="{{ node.node_id }}">
 
                 <div xmlns="http://www.w3.org/1999/xhtml" class="block-container"
                      style="font-size: {{ font_size }}px;">
@@ -110,5 +122,81 @@
             </foreignObject>
         {% endfor %}
     </svg>
+    </div>
+    <script>
+        (function () {
+            "use strict";
+
+            const scrollContainer = document.getElementById("viz-scroll");
+            const nodes = Array.from(document.querySelectorAll("[data-node-id]"));
+            const nodesById = new Map();
+            let selectedNodeId = null;
+
+            nodes.forEach(function (nodeEl) {
+                const nodeId = nodeEl.getAttribute("data-node-id");
+                if (nodeId) {
+                    nodesById.set(nodeId, nodeEl);
+                }
+            });
+
+            function setSelectedNode(nodeId) {
+                selectedNodeId = nodeId === null || nodeId === undefined || nodeId === "" ? null : String(nodeId);
+                nodes.forEach(function (nodeEl) {
+                    const nodeElId = nodeEl.getAttribute("data-node-id");
+                    nodeEl.classList.toggle("selected", selectedNodeId !== null && nodeElId === selectedNodeId);
+                });
+            }
+
+            function focusNode(nodeId) {
+                if (!scrollContainer || !nodeId) {
+                    return;
+                }
+                const nodeEl = nodesById.get(String(nodeId));
+                if (!nodeEl) {
+                    return;
+                }
+
+                const containerRect = scrollContainer.getBoundingClientRect();
+                const nodeRect = nodeEl.getBoundingClientRect();
+                const centerX = scrollContainer.scrollLeft + (nodeRect.left - containerRect.left) + (nodeRect.width / 2);
+                const centerY = scrollContainer.scrollTop + (nodeRect.top - containerRect.top) + (nodeRect.height / 2);
+                const maxLeft = Math.max(0, scrollContainer.scrollWidth - scrollContainer.clientWidth);
+                const maxTop = Math.max(0, scrollContainer.scrollHeight - scrollContainer.clientHeight);
+                const targetLeft = Math.max(0, Math.min(maxLeft, centerX - (scrollContainer.clientWidth / 2)));
+                const targetTop = Math.max(0, Math.min(maxTop, centerY - (scrollContainer.clientHeight / 2)));
+
+                scrollContainer.scrollTo({
+                    left: targetLeft,
+                    top: targetTop,
+                    behavior: "smooth"
+                });
+            }
+
+            nodes.forEach(function (nodeEl) {
+                nodeEl.addEventListener("click", function () {
+                    const nodeId = nodeEl.getAttribute("data-node-id");
+                    setSelectedNode(nodeId);
+                    focusNode(nodeId);
+                    if (window.parent) {
+                        window.parent.postMessage({ type: "nodeSelected", nodeId: nodeId }, "*");
+                    }
+                });
+            });
+
+            window.addEventListener("message", function (event) {
+                const message = event.data;
+                if (!message || typeof message !== "object") {
+                    return;
+                }
+                if (message.type === "selectNode") {
+                    setSelectedNode(message.nodeId);
+                    return;
+                }
+                if (message.type === "focusNode") {
+                    focusNode(message.nodeId);
+                }
+            });
+        })();
+    </script>
 </body>
 </html>

--- a/visualizer_simple/visualizer_simple_plugin/templates/simple.html
+++ b/visualizer_simple/visualizer_simple_plugin/templates/simple.html
@@ -3,16 +3,21 @@
 <head>
     <meta charset="UTF-8">
     <style>
+        html, body { margin: 0; width: 100%; height: 100%; overflow: hidden; }
+        .graph-container { width: 100%; height: 100%; overflow: auto; background: #fafafa; }
+        #viz-svg { display: block; background: #fafafa; border: 1px solid #eee; }
         .node circle { stroke: #333; stroke-width: 1px; transition: fill 0.3s; }
         .node:hover circle { fill: #ff9800; cursor: pointer; }
+        .node.selected circle { stroke: #ff6a00; stroke-width: 4px; fill: #fff4e8; }
+        .node text { pointer-events: none; }
         .edge-line { stroke: #999; stroke-opacity: 0.6; }
     </style>
 </head>
 <body>
     {# You can change measurements for width and height of container as you wish, but then you need to
     adjust them in the plugin accordingly #}
-    <div class="graph-container">
-        <svg width="{{ width }}" height="{{ height }}" style="background: #fafafa; border: 1px solid #eee;">
+    <div id="viz-scroll" class="graph-container">
+        <svg id="viz-svg" width="{{ width }}" height="{{ height }}">
             <defs>
                 <marker id="arrowhead" markerWidth="10" markerHeight="7"
                         refX="{{ radius / scale + 1 }}" refY="3.5" orient="auto">
@@ -33,7 +38,7 @@
 
             {% for node in nodes %}
                 {% set pos = positions[node.node_id] %}
-                <g class="node" id="node-{{ node.node_id }}">
+                <g class="node gv-node" id="node-{{ node.node_id }}" data-node-id="{{ node.node_id }}">
                     <circle cx="{{ pos.x }}" cy="{{ pos.y }}" r="{{ radius }}"
                             fill="white" stroke="black" stroke-width="2" />
                     <text x="{{ pos.x }}" y="{{ pos.y + (font_size/3) }}"
@@ -45,5 +50,80 @@
             {% endfor %}
         </svg>
     </div>
+    <script>
+        (function () {
+            "use strict";
+
+            const scrollContainer = document.getElementById("viz-scroll");
+            const nodes = Array.from(document.querySelectorAll("[data-node-id]"));
+            const nodesById = new Map();
+            let selectedNodeId = null;
+
+            nodes.forEach(function (nodeEl) {
+                const nodeId = nodeEl.getAttribute("data-node-id");
+                if (nodeId) {
+                    nodesById.set(nodeId, nodeEl);
+                }
+            });
+
+            function setSelectedNode(nodeId) {
+                selectedNodeId = nodeId === null || nodeId === undefined || nodeId === "" ? null : String(nodeId);
+                nodes.forEach(function (nodeEl) {
+                    const nodeElId = nodeEl.getAttribute("data-node-id");
+                    nodeEl.classList.toggle("selected", selectedNodeId !== null && nodeElId === selectedNodeId);
+                });
+            }
+
+            function focusNode(nodeId) {
+                if (!scrollContainer || !nodeId) {
+                    return;
+                }
+                const nodeEl = nodesById.get(String(nodeId));
+                if (!nodeEl) {
+                    return;
+                }
+
+                const containerRect = scrollContainer.getBoundingClientRect();
+                const nodeRect = nodeEl.getBoundingClientRect();
+                const centerX = scrollContainer.scrollLeft + (nodeRect.left - containerRect.left) + (nodeRect.width / 2);
+                const centerY = scrollContainer.scrollTop + (nodeRect.top - containerRect.top) + (nodeRect.height / 2);
+                const maxLeft = Math.max(0, scrollContainer.scrollWidth - scrollContainer.clientWidth);
+                const maxTop = Math.max(0, scrollContainer.scrollHeight - scrollContainer.clientHeight);
+                const targetLeft = Math.max(0, Math.min(maxLeft, centerX - (scrollContainer.clientWidth / 2)));
+                const targetTop = Math.max(0, Math.min(maxTop, centerY - (scrollContainer.clientHeight / 2)));
+
+                scrollContainer.scrollTo({
+                    left: targetLeft,
+                    top: targetTop,
+                    behavior: "smooth"
+                });
+            }
+
+            nodes.forEach(function (nodeEl) {
+                nodeEl.addEventListener("click", function () {
+                    const nodeId = nodeEl.getAttribute("data-node-id");
+                    setSelectedNode(nodeId);
+                    focusNode(nodeId);
+                    if (window.parent) {
+                        window.parent.postMessage({ type: "nodeSelected", nodeId: nodeId }, "*");
+                    }
+                });
+            });
+
+            window.addEventListener("message", function (event) {
+                const message = event.data;
+                if (!message || typeof message !== "object") {
+                    return;
+                }
+                if (message.type === "selectNode") {
+                    setSelectedNode(message.nodeId);
+                    return;
+                }
+                if (message.type === "focusNode") {
+                    focusNode(message.nodeId);
+                }
+            });
+        })();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
Closes #39

Implemented end-to-end graph loading + visualization in graph_explorer.

Included:
- File upload UI + POST /api/graph/load (JSON/CSV by extension)
- Active graph storage with graph_id + UI state updates after load
- Visualizer rendering via iframe srcdoc using /api/render and graph_id
- Directed/undirected toggle wired to render requests
- Cross-view selection sync (Tree ↔ Main iframe) with focus/centering
- Tree auto-scroll to selected node
- UI layout improvements (compact toolbar, docked console, scrollable panels)

Updated visualizer templates:
- Added data-node-id + message handlers to support selection/focus sync.

Not included:
- backend search/filter execution
- CLI backend execution