### PR TITLE
M2: Add 501 stub endpoints for CLI/Search/Filter + frontend wiring

### DIFF
--- a/graph_explorer/explorer/urls.py
+++ b/graph_explorer/explorer/urls.py
@@ -8,5 +8,9 @@ urlpatterns = [
     path("", views.index, name="index"),
     path("api/mock-graph/", views.mock_graph_api, name="mock-graph-api"),
     path("api/graph/load", views.load_graph_api, name="graph-load-api"),
+    path("api/cli/execute", views.cli_execute_api, name="cli-execute-api"),
+    path("api/graph/search", views.graph_search_api, name="graph-search-api"),
+    path("api/graph/filter", views.graph_filter_api, name="graph-filter-api"),
+    path("api/workspace/reset", views.workspace_reset_api, name="workspace-reset-api"),
     path("api/render/", views.render_visualizer_api, name="render-visualizer-api"),
 ]


### PR DESCRIPTION
Closes #41

Added backend stub endpoints returning 501 Not Implemented with stable JSON contracts:
- POST /api/cli/execute
- POST /api/graph/search
- POST /api/graph/filter
- (optional) POST /api/workspace/reset

Also wired frontend triggers (no graph changes):
- Console Run -> /api/cli/execute
- Search (Enter only) -> /api/graph/search
- Filter (Apply only) -> /api/graph/filter

Responses are surfaced in the console/status UI. No backend logic is implemented yet.