### PR TITLE
M3: explicit datasource plugin selection

### DIFF
--- a/graph_explorer/explorer/templates/explorer/index.html
+++ b/graph_explorer/explorer/templates/explorer/index.html
@@ -15,13 +15,12 @@
                     >
                     <button id="load-graph-button" type="button" class="placeholder-button">Load</button>
                 </div>
-                <div class="toolbar-inline-feedback">
-                    <span id="selected-file-name" class="placeholder-text">No file selected</span>
-                    <p id="file-load-status" class="toolbar-feedback">Select a JSON or CSV file to load.</p>
+                <div class="datasource-row">
+                    <label for="datasource-plugin-select">Datasource</label>
+                    <select id="datasource-plugin-select" aria-label="Datasource plugin selector"></select>
                 </div>
-                <div id="workspace-selector-area" class="workspace-selector-area">
+                <div id="workspace-selector-area" class="workspace-selector-area" hidden>
                     <div id="workspace-selector-list" class="workspace-selector-list" role="tablist" aria-label="Workspace selector"></div>
-                    <p id="workspace-selector-empty" class="toolbar-feedback">No workspaces loaded</p>
                 </div>
             </section>
 

--- a/graph_explorer/explorer/urls.py
+++ b/graph_explorer/explorer/urls.py
@@ -7,6 +7,7 @@ app_name = "explorer"
 urlpatterns = [
     path("", views.index, name="index"),
     path("api/mock-graph/", views.mock_graph_api, name="mock-graph-api"),
+    path("api/datasources/", views.datasource_plugins_api, name="datasource-plugins-api"),
     path("api/graph/load/", views.load_graph_api, name="graph-load-api"),
     path("api/cli/execute/", views.cli_execute_api, name="cli-execute-api"),
     path("api/graph/search/", views.graph_search_api, name="graph-search-api"),

--- a/graph_explorer/explorer/views.py
+++ b/graph_explorer/explorer/views.py
@@ -52,6 +52,9 @@ DATASOURCE_BY_EXTENSION = {
     ".json": "json",
     ".csv": "csv",
 }
+DATASOURCE_EXTENSIONS_BY_PLUGIN: dict[str, set[str]] = {}
+for extension, plugin_name in DATASOURCE_BY_EXTENSION.items():
+    DATASOURCE_EXTENSIONS_BY_PLUGIN.setdefault(plugin_name, set()).add(extension)
 SUPPORTED_VISUALIZERS = {"simple", "block"}
 
 
@@ -107,18 +110,49 @@ def _format_available_plugins(plugin_names: list[str]) -> str:
     return f" (available: {', '.join(sorted(plugin_names))})"
 
 
-def _build_datasource_map() -> dict[str, tuple[str, object | None, str]]:
+def _build_datasource_plugin_payloads() -> list[dict[str, object]]:
+    # Build datasource plugin options directly from registry discovery.
     registry = PluginRegistry()
-    discovered = registry.list_datasources()
-    missing_detail = _format_available_plugins(discovered)
-    return {
-        extension: (
-            plugin_name,
-            registry.get_datasource(plugin_name),
-            missing_detail,
+    payloads: list[dict[str, object]] = []
+    for datasource_name in sorted(registry.list_datasources()):
+        display_name = datasource_name
+        datasource_cls = registry.get_datasource(datasource_name)
+        if datasource_cls is not None:
+            try:
+                datasource = datasource_cls()
+                resolved_display_name = getattr(datasource, "display_name", None)
+                if isinstance(resolved_display_name, str) and resolved_display_name.strip():
+                    display_name = resolved_display_name.strip()
+            except Exception:
+                pass
+
+        payloads.append(
+            {
+                "id": datasource_name,
+                "name": display_name,
+                "extensions": sorted(DATASOURCE_EXTENSIONS_BY_PLUGIN.get(datasource_name, set())),
+            }
         )
-        for extension, plugin_name in DATASOURCE_BY_EXTENSION.items()
-    }
+    return payloads
+
+
+def _validate_datasource_file_match(datasource_name: str, extension: str) -> str | None:
+    # Reject obvious extension mismatches for known datasource plugins.
+    if not extension:
+        return None
+
+    expected_extensions = DATASOURCE_EXTENSIONS_BY_PLUGIN.get(datasource_name)
+    if not expected_extensions:
+        return None
+
+    if extension in expected_extensions:
+        return None
+
+    expected_label = ", ".join(sorted(expected_extensions))
+    return (
+        f"Selected datasource plugin '{datasource_name}' does not match file extension '{extension}'. "
+        f"Expected: {expected_label}."
+    )
 
 
 def _load_graph_from_upload(uploaded_file: UploadedFile, suffix: str, datasource_cls: object) -> Graph:
@@ -160,6 +194,16 @@ def index(request: HttpRequest) -> HttpResponse:
 
 def mock_graph_api(request: HttpRequest) -> JsonResponse:
     return JsonResponse(MOCK_GRAPH_DATA)
+
+
+@require_GET
+def datasource_plugins_api(request: HttpRequest) -> JsonResponse:
+    return JsonResponse(
+        {
+            "ok": True,
+            "datasources": _build_datasource_plugin_payloads(),
+        }
+    )
 
 
 def _parse_flag(tokens: list[str], name: str) -> str | None:
@@ -545,22 +589,27 @@ def load_graph_api(request: HttpRequest) -> JsonResponse:
     if uploaded_file is None:
         return _json_error("missing file", status=400)
 
+    datasource_name = str(request.POST.get("datasource") or "").strip()
+    if not datasource_name:
+        return _json_error("Missing datasource plugin selection.", status=400)
+
+    registry = PluginRegistry()
+    datasource_cls = registry.get_datasource(datasource_name)
+    if datasource_cls is None:
+        available_detail = _format_available_plugins(registry.list_datasources())
+        return _json_error(f"Datasource plugin '{datasource_name}' is not available{available_detail}", status=400)
+
     filename = str(uploaded_file.name or "uploaded-file")
     extension = Path(filename).suffix.lower()
-    datasource_map = _build_datasource_map()
-
-    if extension not in datasource_map:
-        return _json_error("Unsupported file extension. Allowed extensions are .json and .csv.", status=400)
-
-    source_name, datasource_cls, missing_detail = datasource_map[extension]
-    if datasource_cls is None:
-        return _json_error(f"The '{source_name}' datasource plugin is not available{missing_detail}", status=501)
+    mismatch_error = _validate_datasource_file_match(datasource_name, extension)
+    if mismatch_error:
+        return _json_error(mismatch_error, status=400)
 
     try:
         try:
             graph = _load_graph_from_upload(uploaded_file=uploaded_file, suffix=extension, datasource_cls=datasource_cls)
         except Exception as exc:
-            return _json_error(f"Failed to parse '{filename}' as {source_name}: {exc}", status=400)
+            return _json_error(f"Failed to parse '{filename}' as {datasource_name}: {exc}", status=400)
 
         graph_id = str(uuid4())
         original_graph = _clone_graph(graph)
@@ -583,7 +632,7 @@ def load_graph_api(request: HttpRequest) -> JsonResponse:
                     "node_count": len(nodes) if isinstance(nodes, list) else 0,
                     "edge_count": len(edges) if isinstance(edges, list) else 0,
                     "filename": filename,
-                    "source": source_name,
+                    "source": datasource_name,
                 },
                 "graph": graph_payload,
             },

--- a/graph_explorer/static/css/graph_explorer.css
+++ b/graph_explorer/static/css/graph_explorer.css
@@ -130,6 +130,28 @@ body {
     min-width: 0;
 }
 
+.datasource-row {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    gap: 0.35rem;
+    min-height: 34px;
+}
+
+.datasource-row label {
+    font-size: 0.78rem;
+    color: var(--muted);
+}
+
+.datasource-row select {
+    width: 100%;
+    min-width: 0;
+}
+
+.toolbar-feedback.is-error {
+    color: #b4232d;
+}
+
 .search-row {
     display: flex;
     align-items: center;
@@ -154,7 +176,6 @@ body {
     display: flex;
     flex-direction: column;
     gap: 0.2rem;
-    min-height: 1.8rem;
 }
 
 .workspace-selector-list {

--- a/graph_explorer/static/js/api.js
+++ b/graph_explorer/static/js/api.js
@@ -2,6 +2,7 @@
     "use strict";
 
     const ENDPOINTS = Object.freeze({
+        datasourcePlugins: "/api/datasources/",
         graphLoad: "/api/graph/load/",
         cliExecute: "/api/cli/execute/",
         graphSearch: "/api/graph/search/",
@@ -66,9 +67,10 @@
     }
 
     // Upload a graph file and return a validated graph payload from the backend.
-    async function loadGraphFile(file) {
+    async function loadGraphFile(file, datasourcePlugin) {
         const formData = new FormData();
         formData.append("file", file);
+        formData.append("datasource", datasourcePlugin);
 
         const response = await fetch(ENDPOINTS.graphLoad, {
             method: "POST",
@@ -104,6 +106,54 @@
         };
     }
 
+    // Load datasource plugins discovered by backend plugin registry.
+    async function loadDatasourcePlugins() {
+        const response = await fetch(ENDPOINTS.datasourcePlugins, {
+            method: "GET",
+            headers: { Accept: "application/json" }
+        });
+
+        let payload = null;
+        try {
+            payload = await response.json();
+        } catch {
+            payload = null;
+        }
+
+        if (!response.ok) {
+            const errorMessage = payload && payload.error ? payload.error : `HTTP ${response.status}`;
+            throw new Error(errorMessage);
+        }
+
+        const rawDatasources = payload && Array.isArray(payload.datasources) ? payload.datasources : null;
+        if (!payload || payload.ok !== true || !rawDatasources) {
+            throw new Error("Invalid datasource plugin response shape; expected { ok, datasources }.");
+        }
+
+        return rawDatasources
+            .map(function (item) {
+                if (!item || typeof item !== "object") {
+                    return null;
+                }
+                const id = typeof item.id === "string" ? item.id.trim() : "";
+                const name = typeof item.name === "string" ? item.name.trim() : "";
+                const extensions = Array.isArray(item.extensions)
+                    ? item.extensions.filter(function (entry) {
+                        return typeof entry === "string" && entry.trim().length > 0;
+                    })
+                    : [];
+                if (!id) {
+                    return null;
+                }
+                return {
+                    id: id,
+                    name: name || id,
+                    extensions: extensions
+                };
+            })
+            .filter(Boolean);
+    }
+
     // Build a render endpoint URL for a specific graph, visualizer, and direction mode.
     function buildVisualizerRenderUrl(visualizerId, isDirected, graphId) {
         const params = new URLSearchParams({
@@ -132,6 +182,7 @@
     global.GraphExplorerApi = {
         ENDPOINTS: ENDPOINTS,
         postJsonRequest: postJsonRequest,
+        loadDatasourcePlugins: loadDatasourcePlugins,
         loadGraphFile: loadGraphFile,
         loadVisualizerOutput: loadVisualizerOutput
     };

--- a/graph_explorer/static/js/app.js
+++ b/graph_explorer/static/js/app.js
@@ -17,6 +17,10 @@
         activeGraphId: null,
         isDirected: DEFAULT_DIRECTED,
         selectedNodeId: null,
+        datasourcePlugins: [],
+        datasourcePluginsStatus: "loading",
+        datasourcePluginsErrorMessage: null,
+        selectedDatasourcePlugin: "",
         selectedUploadFile: null,
         selectedUploadFilename: "",
         graph: null,
@@ -62,6 +66,9 @@
         }
         if (typeof window.GraphExplorerApi.postJsonRequest !== "function") {
             throw new Error("GraphExplorerApi.postJsonRequest is not available.");
+        }
+        if (typeof window.GraphExplorerApi.loadDatasourcePlugins !== "function") {
+            throw new Error("GraphExplorerApi.loadDatasourcePlugins is not available.");
         }
         if (typeof window.GraphExplorerApi.loadGraphFile !== "function") {
             throw new Error("GraphExplorerApi.loadGraphFile is not available.");
@@ -402,6 +409,35 @@
         treeViewController.resetState();
     }
 
+    // Load datasource plugin options from backend registry discovery.
+    async function loadDatasourcePlugins() {
+        state.datasourcePluginsStatus = "loading";
+        state.datasourcePluginsErrorMessage = null;
+        renderAll();
+
+        try {
+            const datasourcePlugins = await apiClient.loadDatasourcePlugins();
+            state.datasourcePlugins = Array.isArray(datasourcePlugins) ? datasourcePlugins : [];
+            const hasSelectedDatasource = state.datasourcePlugins.some(function (plugin) {
+                return plugin && plugin.id === state.selectedDatasourcePlugin;
+            });
+            if (!hasSelectedDatasource) {
+                state.selectedDatasourcePlugin = "";
+            }
+            state.datasourcePluginsStatus = "success";
+            state.datasourcePluginsErrorMessage = null;
+        } catch (error) {
+            console.warn(`Graph Explorer: unable to load ${apiEndpoints.datasourcePlugins}.`, error);
+            state.datasourcePlugins = [];
+            state.selectedDatasourcePlugin = "";
+            state.datasourcePluginsStatus = "error";
+            state.datasourcePluginsErrorMessage =
+                `Failed to load datasource plugins (${getDatasourcePluginFetchErrorMessage(error)})`;
+        }
+
+        renderAll();
+    }
+
     // Upload a graph file, create/update workspace state, and activate it.
     async function loadGraphData(file) {
         if (file && file.name) {
@@ -417,6 +453,18 @@
             return;
         }
 
+        const selectedDatasourcePlugin = state.selectedDatasourcePlugin
+            ? String(state.selectedDatasourcePlugin).trim()
+            : "";
+        if (!selectedDatasourcePlugin) {
+            state.graphFetchStatus = "error";
+            state.graphFetchErrorMessage = "Please choose a datasource plugin before loading.";
+            state.graphFetchLastLoadedAt = null;
+            state.graphFetchMeta = null;
+            renderAll();
+            return;
+        }
+
         clearGraphFetchSuccessHideTimeout();
         syncActiveWorkspaceFromState();
         state.graphFetchStatus = "loading";
@@ -425,7 +473,7 @@
         renderAll();
 
         try {
-            const payload = await apiClient.loadGraphFile(file);
+            const payload = await apiClient.loadGraphFile(file, selectedDatasourcePlugin);
             const graphState = toGraphState(payload.graph);
             if (!graphState) {
                 throw new Error("Invalid graph payload.");
@@ -633,11 +681,94 @@
         }
     }
 
+    function getDatasourcePluginFetchErrorMessage(error) {
+        if (error && typeof error.message === "string" && error.message.trim()) {
+            return error.message.trim();
+        }
+        return "Unexpected error.";
+    }
+
+    // Build datasource plugin dropdown option labels.
+    function getDatasourcePluginOptionLabel(plugin) {
+        if (!plugin || typeof plugin !== "object") {
+            return "";
+        }
+
+        const pluginId = typeof plugin.id === "string" ? plugin.id.trim() : "";
+        const pluginName = typeof plugin.name === "string" ? plugin.name.trim() : "";
+        const extensions = Array.isArray(plugin.extensions) ? plugin.extensions : [];
+        const extensionLabel = extensions.length ? ` [${extensions.join(", ")}]` : "";
+        if (pluginName && pluginName !== pluginId) {
+            return `${pluginName} (${pluginId})${extensionLabel}`;
+        }
+        return `${pluginId}${extensionLabel}`;
+    }
+
+    function getDatasourcePluginStatusLabel() {
+        if (state.datasourcePluginsStatus === "loading") {
+            return "Loading datasource plugins...";
+        }
+        if (state.datasourcePluginsStatus === "error") {
+            return state.datasourcePluginsErrorMessage || "Failed to load datasource plugins.";
+        }
+        if (!state.datasourcePlugins.length) {
+            return "No datasource plugins discovered.";
+        }
+        if (!state.selectedDatasourcePlugin) {
+            return "";
+        }
+
+        const selectedPlugin = state.datasourcePlugins.find(function (plugin) {
+            return plugin && plugin.id === state.selectedDatasourcePlugin;
+        });
+        if (!selectedPlugin) {
+            return `Datasource plugin: ${state.selectedDatasourcePlugin}`;
+        }
+        return `Datasource plugin: ${getDatasourcePluginOptionLabel(selectedPlugin)}`;
+    }
+
+    function renderDatasourcePluginSelect(selectElement) {
+        if (!selectElement) {
+            return;
+        }
+
+        const selectedDatasourcePlugin = state.selectedDatasourcePlugin || "";
+        const placeholderLabel = state.datasourcePluginsStatus === "loading"
+            ? "Loading datasource plugins..."
+            : "Select datasource plugin";
+
+        selectElement.innerHTML = "";
+
+        const placeholderOption = document.createElement("option");
+        placeholderOption.value = "";
+        placeholderOption.textContent = placeholderLabel;
+        selectElement.appendChild(placeholderOption);
+
+        state.datasourcePlugins.forEach(function (plugin) {
+            const option = document.createElement("option");
+            option.value = plugin.id;
+            option.textContent = getDatasourcePluginOptionLabel(plugin);
+            selectElement.appendChild(option);
+        });
+
+        selectElement.value = selectedDatasourcePlugin;
+        if (selectElement.value !== selectedDatasourcePlugin) {
+            state.selectedDatasourcePlugin = "";
+        }
+
+        selectElement.disabled =
+            state.graphFetchStatus === "loading" ||
+            state.datasourcePluginsStatus === "loading" ||
+            state.datasourcePlugins.length === 0;
+    }
+
     // Resolve file upload controls used by load/render workflow.
     function getFileInputElements() {
         return {
             fileInput: document.getElementById("graph-file-input"),
             loadButton: document.getElementById("load-graph-button"),
+            datasourceSelect: document.getElementById("datasource-plugin-select"),
+            datasourceStatus: document.getElementById("datasource-plugin-status"),
             selectedFileName: document.getElementById("selected-file-name"),
             status: document.getElementById("file-load-status")
         };
@@ -766,8 +897,11 @@
 
     // Build the file-upload helper/status line under the file picker.
     function getFileLoadStatusLabel() {
+        if (!state.selectedDatasourcePlugin) {
+            return "";
+        }
         if (!state.selectedUploadFile) {
-            return "Select a JSON or CSV file to load.";
+            return "";
         }
         if (state.graphFetchStatus === "loading") {
             return `Uploading ${state.selectedUploadFilename}...`;
@@ -785,18 +919,37 @@
     // Render file picker labels/buttons from current upload state.
     function renderFileInputState() {
         const refs = getFileInputElements();
+        renderDatasourcePluginSelect(refs.datasourceSelect);
+
+        if (refs.datasourceStatus) {
+            const datasourceStatusLabel = getDatasourcePluginStatusLabel();
+            refs.datasourceStatus.textContent = datasourceStatusLabel;
+            refs.datasourceStatus.hidden = !datasourceStatusLabel;
+            const hasDatasourceError =
+                state.datasourcePluginsStatus === "error" ||
+                (state.datasourcePluginsStatus === "success" && state.datasourcePlugins.length === 0);
+            refs.datasourceStatus.classList.toggle("is-error", hasDatasourceError);
+        }
+
         if (refs.selectedFileName) {
-            refs.selectedFileName.textContent = state.selectedUploadFile
+            const selectedFileNameLabel = state.selectedUploadFile
                 ? state.selectedUploadFilename
-                : "No file selected";
+                : "";
+            refs.selectedFileName.textContent = selectedFileNameLabel;
+            refs.selectedFileName.hidden = !selectedFileNameLabel;
         }
 
         if (refs.status) {
-            refs.status.textContent = getFileLoadStatusLabel();
+            const fileLoadStatusLabel = getFileLoadStatusLabel();
+            refs.status.textContent = fileLoadStatusLabel;
+            refs.status.hidden = !fileLoadStatusLabel;
         }
 
         if (refs.loadButton) {
-            refs.loadButton.disabled = state.graphFetchStatus === "loading" || !state.selectedUploadFile;
+            refs.loadButton.disabled =
+                state.graphFetchStatus === "loading" ||
+                !state.selectedUploadFile ||
+                !state.selectedDatasourcePlugin;
         }
     }
 
@@ -805,6 +958,20 @@
         const refs = getFileInputElements();
         if (!refs.fileInput) {
             return;
+        }
+
+        if (refs.datasourceSelect) {
+            refs.datasourceSelect.addEventListener("change", function (event) {
+                const selectedValue = event.target && typeof event.target.value === "string"
+                    ? event.target.value.trim()
+                    : "";
+                state.selectedDatasourcePlugin = selectedValue;
+                clearGraphFetchSuccessHideTimeout();
+                if (state.graphFetchStatus === "success") {
+                    state.graphFetchStatus = "idle";
+                }
+                renderAll();
+            });
         }
 
         refs.fileInput.addEventListener("change", function (event) {
@@ -1227,6 +1394,7 @@
             renderBirdView();
         });
         renderAll();
+        loadDatasourcePlugins();
     }
 
     document.addEventListener("DOMContentLoaded", initializeApp);

--- a/graph_explorer/static/js/workspace_ui.js
+++ b/graph_explorer/static/js/workspace_ui.js
@@ -29,8 +29,8 @@
         // Resolve workspace selector elements from the current document.
         function getWorkspaceSelectorElements() {
             return {
-                list: document.getElementById("workspace-selector-list"),
-                empty: document.getElementById("workspace-selector-empty")
+                area: document.getElementById("workspace-selector-area"),
+                list: document.getElementById("workspace-selector-list")
             };
         }
 
@@ -45,14 +45,14 @@
             const workspaceIdsSource = getWorkspaceIds();
             const workspaceIds = Array.isArray(workspaceIdsSource) ? workspaceIdsSource : [];
             if (!workspaceIds.length) {
-                if (refs.empty) {
-                    refs.empty.hidden = false;
+                if (refs.area) {
+                    refs.area.hidden = true;
                 }
                 return;
             }
 
-            if (refs.empty) {
-                refs.empty.hidden = true;
+            if (refs.area) {
+                refs.area.hidden = false;
             }
 
             const activeGraphId = getActiveGraphId();


### PR DESCRIPTION
Closes #78

Improved graph loading so datasource plugin selection is now explicit in the UI:

- Added a datasource plugin selector to the graph loading flow
- Populated available datasource plugins through the registry/discovery mechanism
- Kept file upload as part of the loading process
- Sent both the selected datasource plugin and uploaded file to the backend
- Updated backend graph loading to resolve the datasource through the registry using the selected plugin